### PR TITLE
chore(gh): add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+---
+name: Manage Stale Items
+
+on:
+  schedule:
+    - cron: 00 00 * * *
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          days-before-stale: 360
+          days-before-close: 30
+          exempt-issue-labels: 'needs-triage'
+          exempt-pr-labels: 'needs-review'
+          remove-stale-when-updated: true
+          delete-branch: false
+          stale-issue-label: stale
+          stale-issue-message: >
+            'Marking this issue as stale due to inactivity. This helps us focus
+            on the active issues. If this issue receives no comments in the next
+            30 days it will automatically be closed.
+
+
+            If this issue was automatically closed and you feel this issue
+            should be reopened, we encourage creating a new issue linking back
+            to this one for added context.
+
+            Thank you!'
+          stale-pr-label: stale
+          stale-pr-message: >
+            'Marking this pull request as stale due to inactivity. This helps us
+            focus on the active pull requests. If this pull request receives no
+            comments in the next 30 days it will automatically be closed.
+
+            If this pull request was automatically closed and you feel this pull
+            request should be reopened, we encourage creating a new pull request
+            linking back to this one for added context.
+
+            Thank you!'


### PR DESCRIPTION
**Summary of Pull Request**

Adds workflow to label issues and pull requests as stale after x days.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
