### PR TITLE
chore: remove use of `io/ioutil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@
 
 > Release Date: 2025-01-13
 
-- License changed from Apache License 2.0 to Mozilla Public License 2.0.
+General:
+
 - Transferred to [`vmware/terraform-provider-hcx`](https://github.com/vmware/terraform-provider-hcx) from [`adeleporte/terraform-provider-hcx`](https://github.com/adeleporte/terraform-provider-hcx).
+- License changed from Apache License 2.0 to Mozilla Public License 2.0. [#17](https://github.com/vmware/terraform-provider-hcx/pull/17)
+
+Chores:
+
+- Updated Go to v1.22.7. [#47](https://github.com/vmware/terraform-provider-hcx/pull/47)
+- Removes the use of `io/ioutil`. As of Go 1.16, the same functionality is now provided by package `io` or package `os`, and those implementations are preferred. [#48](https://github.com/vmware/terraform-provider-hcx/pull/48)
 
 ## [v0.4.3](https://github.com/vmware/terraform-provider-hcx/releases/tag/v0.4.3)
 

--- a/hcx/client.go
+++ b/hcx/client.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -99,7 +99,7 @@ func (c *Client) HcxConnectorAuthenticate() error {
 
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (c *Client) doRequest(req *http.Request) (*http.Response, []byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -217,7 +217,7 @@ func (c *Client) doAdminRequest(req *http.Request) (*http.Response, []byte, erro
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -249,7 +249,7 @@ func (c *Client) doVmcRequest(req *http.Request) (*http.Response, []byte, error)
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Removes the use of `io/ioutil`.

As of Go 1.16, the same functionality is now provided by package `io` or package `os`, and those implementations are preferred in new code.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Dependent on #47.

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
