### PR TITLE
chore: errcheck

### DIFF
--- a/hcx/activation.go
+++ b/hcx/activation.go
@@ -35,7 +35,11 @@ func PostActivate(c *Client, body ActivateBody) (ActivateBody, error) {
 	resp := ActivateBody{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {
@@ -94,7 +98,11 @@ func DeleteActivate(c *Client, body ActivateBody) (ActivateBody, error) {
 	resp := ActivateBody{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/certificate.go
+++ b/hcx/certificate.go
@@ -26,7 +26,11 @@ func InsertCertificate(c *Client, body InsertCertificateBody) (InsertCertificate
 	resp := InsertCertificateResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/admin/certificates", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/client.go
+++ b/hcx/client.go
@@ -100,7 +100,10 @@ func (c *Client) HcxConnectorAuthenticate() error {
 
 		// Check if SSO is ready
 		var xmlmessage Entries
-		xml.Unmarshal(body, &xmlmessage)
+		err = xml.Unmarshal(body, &xmlmessage)
+		if err != nil {
+			return err
+		}
 
 		certificate_pb := false
 		for _, j := range xmlmessage.Entry {

--- a/hcx/compute_profile.go
+++ b/hcx/compute_profile.go
@@ -102,7 +102,11 @@ func InsertComputeProfile(c *Client, body InsertComputeProfileBody) (InsertCompu
 	resp := InsertComputeProfileResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/l2_extension.go
+++ b/hcx/l2_extension.go
@@ -80,7 +80,11 @@ func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2Extention
 	resp := InsertL2ExtentionResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/l2Extensions", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/location.go
+++ b/hcx/location.go
@@ -33,7 +33,10 @@ type GetLocationResult struct {
 func SetLocation(c *Client, body SetLocationBody) error {
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		return err
+	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/location", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/network_profile.go
+++ b/hcx/network_profile.go
@@ -74,7 +74,11 @@ func InsertNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 	resp := NetworkProfileResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/admin/hybridity/api/networks", c.HostURL), &buf)
 	if err != nil {
@@ -111,7 +115,11 @@ func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return NetworkProfileBody{}, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
@@ -154,7 +162,11 @@ func GetNetworkProfileById(c *Client, id string) (NetworkProfileBody, error) {
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return NetworkProfileBody{}, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
@@ -219,7 +231,11 @@ func UpdateNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 	resp := NetworkProfileResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectId), &buf)
 	if err != nil {

--- a/hcx/role_mapping.go
+++ b/hcx/role_mapping.go
@@ -28,7 +28,11 @@ func PutRoleMapping(c *Client, body []RoleMapping) (RoleMappingResult, error) {
 	resp := RoleMappingResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/roleMappings", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/service_mesh.go
+++ b/hcx/service_mesh.go
@@ -65,7 +65,11 @@ func InsertServiceMesh(c *Client, body InsertServiceMeshBody) (InsertServiceMesh
 	resp := InsertServiceMeshResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/serviceMesh", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/site_pairing.go
+++ b/hcx/site_pairing.go
@@ -66,7 +66,11 @@ func InsertSitePairing(c *Client, body RemoteCloudConfigBody) (PostRemoteCloudCo
 	resp := PostRemoteCloudConfigResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/cloudConfigs", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/sso.go
+++ b/hcx/sso.go
@@ -75,7 +75,11 @@ func InsertSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 	resp := InsertSSOResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice", c.HostURL), &buf)
 	if err != nil {
@@ -106,7 +110,11 @@ func UpdateSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 	resp := InsertSSOResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice/%s", c.HostURL, body.Data.Items[0].Config.UUID), &buf)
 	if err != nil {

--- a/hcx/utils.go
+++ b/hcx/utils.go
@@ -302,7 +302,11 @@ func GetLocalContainer(c *Client) (PostResouceContainerListResultDataItem, error
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return PostResouceContainerListResultDataItem{}, err
+	}
 
 	resp := PostResouceContainerListResult{}
 
@@ -342,7 +346,11 @@ func GetRemoteContainer(c *Client) (PostResouceContainerListResultDataItem, erro
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return PostResouceContainerListResultDataItem{}, err
+	}
 
 	resp := PostResouceContainerListResult{}
 
@@ -381,7 +389,11 @@ func GetNetworkBacking(c *Client, endpointid string, network string, network_typ
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return Dvpg{}, err
+	}
 
 	resp := PostNetworkBackingResult{}
 
@@ -461,7 +473,11 @@ func GetVcDatastore(c *Client, datastore_name string, vcuuid string, cluster str
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return GetVcDatastoreResultDataItem{}, err
+	}
 
 	resp := GetVcDatastoreResult{}
 
@@ -506,7 +522,11 @@ func GetVcDvs(c *Client, dvs_name string, vcuuid string, cluster string) (GetVcD
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return GetVcDvsResultDataItem{}, err
+	}
 
 	resp := GetVcDvsResult{}
 
@@ -549,7 +569,11 @@ func GetRemoteCloudList(c *Client) (PostCloudListResult, error) {
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return PostCloudListResult{}, err
+	}
 
 	resp := PostCloudListResult{}
 
@@ -586,7 +610,11 @@ func GetLocalCloudList(c *Client) (PostCloudListResult, error) {
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return PostCloudListResult{}, err
+	}
 
 	resp := PostCloudListResult{}
 
@@ -624,7 +652,11 @@ func GetAppliance(c *Client, endpointId string, service_mesh_id string) (GetAppl
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return GetApplianceResultItem{}, err
+	}
 
 	resp := GetApplianceResult{}
 
@@ -669,7 +701,11 @@ func GetAppliances(c *Client, endpointId string, service_mesh_id string) ([]GetA
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return []GetApplianceResultItem{}, err
+	}
 
 	resp := GetApplianceResult{}
 

--- a/hcx/vcenter.go
+++ b/hcx/vcenter.go
@@ -45,7 +45,11 @@ func InsertvCenter(c *Client, body InsertvCenterBody) (InsertvCenterResult, erro
 	resp := InsertvCenterResult{}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return resp, err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/vcenter", c.HostURL), &buf)
 	if err != nil {

--- a/hcx/vmc.go
+++ b/hcx/vmc.go
@@ -99,7 +99,11 @@ func CloudAuthenticate(client *Client, token string) error {
 	}
 
 	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(body)
+	err := json.NewEncoder(&buf).Encode(body)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sessions", c.HostURL), &buf)
 	if err != nil {

--- a/resource_compute_profile.go
+++ b/resource_compute_profile.go
@@ -299,12 +299,12 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return diag.FromErr(err)
+	}
 
 	res2, err := hcx.InsertComputeProfile(client, body)
-
 	if err != nil {
-		//return diag.FromErr(errors.New(fmt.Sprintf("%s", buf)))
 		return diag.FromErr(err)
 	}
 

--- a/resource_l2_extension.go
+++ b/resource_l2_extension.go
@@ -157,7 +157,9 @@ func resourceL2ExtensionCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return diag.FromErr(err)
+	}
 
 	res2, err := hcx.InsertL2Extension(client, body)
 

--- a/resource_service_mesh.go
+++ b/resource_service_mesh.go
@@ -184,12 +184,13 @@ func resourceServiceMeshCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return diag.FromErr(err)
+	}
 
 	res2, err := hcx.InsertServiceMesh(client, body)
 
 	if err != nil {
-		//return diag.FromErr(errors.New(fmt.Sprintf("%s", buf)))
 		return diag.FromErr(err)
 	}
 

--- a/resource_sso.go
+++ b/resource_sso.go
@@ -117,7 +117,10 @@ func resourceSSODelete(ctx context.Context, d *schema.ResourceData, m interface{
 
 	client := m.(*hcx.Client)
 
-	hcx.DeleteSSO(client, d.Id())
+	_, err := hcx.DeleteSSO(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/resource_vcenter.go
+++ b/resource_vcenter.go
@@ -72,8 +72,11 @@ func resourcevCenterCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	d.SetId(res.InsertvCenterData.Items[0].Config.UUID)
 
-	// Restart App Daemon
-	hcx.AppEngineStop(client)
+	// Restart App Deamon
+	_, err = hcx.AppEngineStop(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// Wait for App Daemon to be stopped
 	for {
@@ -88,7 +91,10 @@ func resourcevCenterCreate(ctx context.Context, d *schema.ResourceData, m interf
 		time.Sleep(5 * time.Second)
 	}
 
-	hcx.AppEngineStart(client)
+	_, err = hcx.AppEngineStart(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// Wait for App Daemon to be started
 	for {
@@ -124,7 +130,10 @@ func resourcevCenterDelete(ctx context.Context, d *schema.ResourceData, m interf
 
 	client := m.(*hcx.Client)
 
-	hcx.DeletevCenter(client, d.Id())
+	_, err := hcx.DeletevCenter(client, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Technical Debt: errcheck

Check the return value to ensure that any issues are caught and handled appropriately.

* [`hcx/activation.go`](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L38-R42): Added error handling for JSON encoding in `PostActivate` and `DeleteActivate` functions. [[1]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L38-R42) [[2]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L97-R105)
* [`hcx/certificate.go`](diffhunk://#diff-73333f714840ba3f587cab1dd634dca4e693d942368b6eb797c530b7d93b5546L29-R33): Added error handling for JSON encoding in `InsertCertificate` function.
* [`hcx/client.go`](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L117-R120): Added error handling for XML unmarshalling in `HcxConnectorAuthenticate` function.
* [`hcx/compute_profile.go`](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL105-R109): Added error handling for JSON encoding in `InsertComputeProfile` function.
* [`hcx/l2_extension.go`](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L83-R87): Added error handling for JSON encoding in `InsertL2Extension` function.
* [`hcx/location.go`](diffhunk://#diff-72c4a571cc2d986147d77adb7f5a56a5abf2b6f18f96dd449f6ee4dbb171a8e3L36-R39): Added error handling for JSON encoding in `SetLocation` function.
* [`hcx/network_profile.go`](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L77-R81): Added error handling for JSON encoding in various functions such as `InsertNetworkProfile`, `GetNetworkProfile`, `GetNetworkProfileById`, and `UpdateNetworkProfile`. [[1]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L77-R81) [[2]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L114-R122) [[3]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L157-R169) [[4]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L222-R238)
* [`hcx/role_mapping.go`](diffhunk://#diff-2c7f9019b79667392dfffd1ba9316acd26e2545f50b01514dc66dbd876004a07L31-R35): Added error handling for JSON encoding in `PutRoleMapping` function.
* [`hcx/service_mesh.go`](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L68-R72): Added error handling for JSON encoding in `InsertServiceMesh` function.
* [`hcx/site_pairing.go`](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L69-R73): Added error handling for JSON encoding in `InsertSitePairing` function.
* [`hcx/sso.go`](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL78-R82): Added error handling for JSON encoding in `InsertSSO` and `UpdateSSO` functions. [[1]](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL78-R82) [[2]](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL109-R117)
* [`hcx/utils.go`](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL305-R309): Added error handling for JSON encoding in various utility functions such as `GetLocalContainer`, `GetRemoteContainer`, `GetNetworkBacking`, `GetVcDatastore`, `GetVcDvs`, `GetRemoteCloudList`, `GetLocalCloudList`, `GetAppliance`, and `GetAppliances`. [[1]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL305-R309) [[2]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL345-R353) [[3]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL384-R396) [[4]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL464-R480) [[5]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL509-R529) [[6]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL552-R576) [[7]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL589-R617) [[8]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL627-R659) [[9]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL672-R708)
* [`hcx/vcenter.go`](diffhunk://#diff-64f1cee2f6ec02f868ddcea76fa5f425afe1c375219396b50363f2905a4090ffL48-R52): Added error handling for JSON encoding in `InsertvCenter` function.
* [`hcx/vmc.go`](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL102-R106): Added error handling for JSON encoding in `HcxCloudAuthenticate` function.
* [`resource_compute_profile.go`](diffhunk://#diff-6249d4a6ecea06e7c758a5ffe69b9f7ef651c9c15b830a99ec6e5ee4fc1c8b86L293-L298): Added error handling for JSON encoding in `resourceComputeProfileCreate` function.
* [`resource_l2_extension.go`](diffhunk://#diff-a5254d75951fdec1b33c61427a07b35ce4ad3427c4d857cc39fa0aace8d94c93L150-R152): Added error handling for JSON encoding in `resourceL2ExtensionCreate` function.
* [`resource_service_mesh.go`](diffhunk://#diff-9e8db08b46b8f699b82b627de91f9a1c1723e3014efe16134a953b8d92b9b921L175-L180): Added error handling for JSON encoding in `resourceServiceMeshCreate` function.
* [`resource_sso.go`](diffhunk://#diff-8da9d9b26535459629508d96dfc572eec9b540afb456cd556959fae9a914f5c8L121-R124): Added error handling for `DeleteSSO` function.
* [`resource_vcenter.go`](diffhunk://#diff-3df6aee17487c06856ec4b209e048adab2a169e71de2a5d1066d65fa4e471979L73-R76): Added error handling for `AppEngineStop`, `AppEngineStart`, and `DeletevCenter` functions in `resourcevCenterCreate` and `resourcevCenterDelete` functions. [[1]](diffhunk://#diff-3df6aee17487c06856ec4b209e048adab2a169e71de2a5d1066d65fa4e471979L73-R76) [[2]](diffhunk://#diff-3df6aee17487c06856ec4b209e048adab2a169e71de2a5d1066d65fa4e471979L88-R94) [[3]](diffhunk://#diff-3df6aee17487c06856ec4b209e048adab2a169e71de2a5d1066d65fa4e471979L124-R133)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Ref: #42

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
