### PR TITLE
chore: gosimple

### DIFF
--- a/hcx/client.go
+++ b/hcx/client.go
@@ -161,7 +161,7 @@ func (c *Client) doRequest(req *http.Request) (*http.Response, []byte, error) {
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-hm-authorization", fmt.Sprintf("%s", c.Token))
+	req.Header.Set("x-hm-authorization", c.Token)
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
@@ -228,8 +228,9 @@ func (c *Client) doVmcRequest(req *http.Request) (*http.Response, []byte, error)
 	req.Header.Set("Content-Type", "application/json")
 
 	if c.HcxToken != "" {
-		req.Header.Set("x-hm-authorization", fmt.Sprintf("%s", c.HcxToken))
+		req.Header.Set("x-hm-authorization", c.HcxToken)
 	}
+
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	res, err := c.HTTPClient.Do(req)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Technical Debt: gosimple

Removed format for arguments that are already a string.

Simplification of header setting:

* [`hcx/client.go`](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L175-R175): In the `doRequest` function, the `x-hm-authorization` header is now set directly using `c.Token` instead of using `fmt.Sprintf`.
* [`hcx/client.go`](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L242-R244): In the `doVmcRequest` function, the `x-hm-authorization` header is now set directly using `c.HcxToken` instead of using `fmt.Sprintf`.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Ref: #42

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
