### PR TITLE
chore: update naming

### DIFF
--- a/data_source_compute_profile.go
+++ b/data_source_compute_profile.go
@@ -43,13 +43,13 @@ func dataSourceComputeProfileRead(ctx context.Context, d *schema.ResourceData, m
 
 	network := d.Get("name").(string)
 
-	cp, err := hcx.GetComputeProfile(client, res.Data.Items[0].EndpointId, network)
+	cp, err := hcx.GetComputeProfile(client, res.Data.Items[0].EndpointID, network)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.SetId(cp.ComputeProfileId)
+	d.SetId(cp.ComputeProfileID)
 
 	return diags
 }

--- a/data_source_network_backing.go
+++ b/data_source_network_backing.go
@@ -48,10 +48,10 @@ func dataSourceNetworkBackingRead(ctx context.Context, d *schema.ResourceData, m
 	client := m.(*hcx.Client)
 
 	network := d.Get("name").(string)
-	vcuuid := d.Get("vcuuid").(string)
-	network_type := d.Get("network_type").(string)
+	vcUUID := d.Get("vcuuid").(string)
+	networkType := d.Get("network_type").(string)
 
-	res, err := hcx.GetNetworkBacking(client, vcuuid, network, network_type)
+	res, err := hcx.GetNetworkBacking(client, vcUUID, network, networkType)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/hcx/client.go
+++ b/hcx/client.go
@@ -105,17 +105,17 @@ func (c *Client) HcxConnectorAuthenticate() error {
 			return err
 		}
 
-		certificate_pb := false
+		certificatePb := false
 		for _, j := range xmlmessage.Entry {
 			if j.Strings[0] == "message" {
 				if j.Strings[1] == "'Trusted root certificates' value should not be empty" {
-					certificate_pb = true
+					certificatePb = true
 					log.Println("Certificate error")
 				}
 			}
 		}
 
-		if !certificate_pb {
+		if !certificatePb {
 			return fmt.Errorf("body: %s", body)
 		}
 
@@ -131,7 +131,7 @@ func (c *Client) HcxConnectorAuthenticate() error {
 }
 
 // NewClient -
-func NewClient(hcx, username *string, password *string, adminusername *string, adminpassword *string, vmc_token *string) (*Client, error) {
+func NewClient(hcx, username *string, password *string, adminUsername *string, adminPassword *string, vmcToken *string) (*Client, error) {
 	c := Client{
 		HTTPClient: &http.Client{
 			Timeout: 60 * time.Second,
@@ -139,10 +139,10 @@ func NewClient(hcx, username *string, password *string, adminusername *string, a
 		HostURL:         *hcx,
 		Username:        *username,
 		Password:        *password,
-		AdminUsername:   *adminusername,
-		AdminPassword:   *adminpassword,
+		AdminUsername:   *adminUsername,
+		AdminPassword:   *adminPassword,
 		IsAuthenticated: false,
-		Token:           *vmc_token,
+		Token:           *vmcToken,
 	}
 
 	return &c, nil

--- a/hcx/compute_profile.go
+++ b/hcx/compute_profile.go
@@ -24,26 +24,26 @@ type InsertComputeProfileBody struct {
 }
 
 type Compute struct {
-	CmpId   string `json:"cmpId"`
-	CmpName string `json:"cmpName"`
-	CmpType string `json:"cmpType"`
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
+	ComputeID   string `json:"cmpId"`
+	ComputeName string `json:"cmpName"`
+	ComputeType string `json:"cmpType"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
 }
 
 type Storage struct {
-	CmpId   string `json:"cmpId"`
-	CmpName string `json:"cmpName"`
-	CmpType string `json:"cmpType"`
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
+	ComputeID   string `json:"cmpId"`
+	ComputeName string `json:"cmpName"`
+	ComputeType string `json:"cmpType"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
 }
 
 type DeploymentContainer struct {
 	Computes          []Compute `json:"compute"`
-	CpuReservation    int       `json:"cpuReservation"`
+	CPUReservation    int       `json:"cpuReservation"`
 	MemoryReservation int       `json:"memoryReservation"`
 	Storage           []Storage `json:"storage"`
 }
@@ -65,11 +65,11 @@ type Service struct {
 }
 
 type Switch struct {
-	CmpID  string `json:"cmpId"`
-	ID     string `json:"id"`
-	MaxMTU int    `json:"maxMtu,omitempty"`
-	Name   string `json:"name"`
-	Type   string `json:"type"`
+	ComputeID string `json:"cmpId"`
+	ID        string `json:"id"`
+	MaxMTU    int    `json:"maxMtu,omitempty"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
 }
 
 type InsertComputeProfileResult struct {
@@ -77,8 +77,8 @@ type InsertComputeProfileResult struct {
 }
 
 type InsertComputeProfileResultData struct {
-	InterconnectTaskId string `json:"interconnectTaskId"`
-	ComputeProfileId   string `json:"computeProfileId"`
+	InterconnectTaskID string `json:"interconnectTaskId"`
+	ComputeProfileID   string `json:"computeProfileId"`
 }
 
 type GetComputeProfileResult struct {
@@ -86,7 +86,7 @@ type GetComputeProfileResult struct {
 }
 
 type GetComputeProfileResultItem struct {
-	ComputeProfileId     string              `json:"computeProfileId"`
+	ComputeProfileID     string              `json:"computeProfileId"`
 	Name                 string              `json:"name"`
 	Compute              []Compute           `json:"compute"`
 	Services             []Service           `json:"services"`
@@ -160,11 +160,11 @@ func DeleteComputeProfile(c *Client, computeprofileID string) (InsertComputeProf
 }
 
 // GetComputeProfile ...
-func GetComputeProfile(c *Client, endpointId string, computeprofileName string) (GetComputeProfileResultItem, error) {
+func GetComputeProfile(c *Client, endpointID string, computeProfileName string) (GetComputeProfileResultItem, error) {
 
 	resp := GetComputeProfileResult{}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles?endpointId=%s", c.HostURL, endpointId), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles?endpointId=%s", c.HostURL, endpointID), nil)
 	if err != nil {
 		fmt.Println(err)
 		return GetComputeProfileResultItem{}, err
@@ -185,7 +185,7 @@ func GetComputeProfile(c *Client, endpointId string, computeprofileName string) 
 	}
 
 	for _, j := range resp.Items {
-		if j.Name == computeprofileName {
+		if j.Name == computeProfileName {
 			return j, nil
 		}
 	}

--- a/hcx/l2_extension.go
+++ b/hcx/l2_extension.go
@@ -13,10 +13,10 @@ import (
 )
 
 type InsertL2ExtensionBody struct {
-	VcGuid             string             `json:"vcGuid"`
+	VcGUID             string             `json:"vcGuid"`
 	Gateway            string             `json:"gateway"`
 	Netmask            string             `json:"netmask"`
-	Dns                []string           `json:"dns"`
+	DNS                []string           `json:"dns"`
 	Destination        Destination        `json:"destination"`
 	DestinationNetwork DestinationNetwork `json:"destinationNetwork"`
 	Features           Features           `json:"features"`
@@ -25,14 +25,14 @@ type InsertL2ExtensionBody struct {
 }
 
 type DestinationNetwork struct {
-	GatewayId string `json:"gatewayId"`
+	GatewayID string `json:"gatewayId"`
 }
 
 type Destination struct {
-	EndpointId   string `json:"endpointId"`
+	EndpointID   string `json:"endpointId"`
 	EndpointName string `json:"endpointName"`
 	EndpointType string `json:"endpointType"`
-	ResourceId   string `json:"resourceId"`
+	ResourceID   string `json:"resourceId"`
 	ResourceName string `json:"resourceName"`
 	ResourceType string `json:"resourceType"`
 }
@@ -43,16 +43,16 @@ type Features struct {
 }
 
 type SourceAppliance struct {
-	ApplianceId string `json:"applianceId"`
+	ApplianceID string `json:"applianceId"`
 }
 
 type SourceNetwork struct {
-	NetworkId   string `json:"networkId"`
+	NetworkID   string `json:"networkId"`
 	NetworkName string `json:"networkName"`
 	NetworkType string `json:"networkType"`
 }
 
-type InsertL2ExtentionResult struct {
+type InsertL2ExtensionResult struct {
 	ID string `json:"id"`
 }
 
@@ -61,7 +61,7 @@ type GetL2ExtensionsResult struct {
 }
 
 type GetL2ExtensionsResultItem struct {
-	StretchId       string          `json:"stretchId"`
+	StretchID       string          `json:"stretchId"`
 	OperationStatus OperationStatus `json:"operationStatus"`
 	SourceNetwork   SourceNetwork   `json:"sourceNetwork"`
 }
@@ -75,9 +75,9 @@ type DeleteL2ExtensionResult struct {
 }
 
 // InsertL2Extention ...
-func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2ExtentionResult, error) {
+func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2ExtensionResult, error) {
 
-	resp := InsertL2ExtentionResult{}
+	resp := InsertL2ExtensionResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
@@ -110,7 +110,7 @@ func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2Extention
 }
 
 // GetL2Extensions ...
-func GetL2Extensions(c *Client, network_name string) (GetL2ExtensionsResultItem, error) {
+func GetL2Extensions(c *Client, networkName string) (GetL2ExtensionsResultItem, error) {
 
 	resp := GetL2ExtensionsResult{}
 
@@ -135,7 +135,7 @@ func GetL2Extensions(c *Client, network_name string) (GetL2ExtensionsResultItem,
 	}
 
 	for _, j := range resp.Items {
-		if j.SourceNetwork.NetworkName == network_name {
+		if j.SourceNetwork.NetworkName == networkName {
 			return j, nil
 		}
 	}

--- a/hcx/location.go
+++ b/hcx/location.go
@@ -14,7 +14,7 @@ import (
 type SetLocationBody struct {
 	City      string  `json:"city"`
 	Country   string  `json:"country"`
-	CityAscii string  `json:"cityAscii"`
+	CityASCII string  `json:"cityAscii"`
 	Province  string  `json:"province"`
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
@@ -24,7 +24,7 @@ type GetLocationResult struct {
 	City      string  `json:"city"`
 	Country   string  `json:"country"`
 	Province  string  `json:"province"`
-	CityAscii string  `json:"cityAscii"`
+	CityASCII string  `json:"cityAscii"`
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 }

--- a/hcx/network_profile.go
+++ b/hcx/network_profile.go
@@ -21,7 +21,7 @@ type NetworkProfileBody struct {
 	Name            string    `json:"name"`
 	L3TenantManaged bool      `json:"l3TenantManaged"`
 	OwnedBySystem   bool      `json:"ownedBySystem"`
-	ObjectId        string    `json:"objectId,omitempty"`
+	ObjectID        string    `json:"objectId,omitempty"`
 }
 
 type Filter struct {
@@ -37,21 +37,21 @@ type Backing struct {
 	BackingID           string `json:"backingId"`
 	BackingName         string `json:"backingName"`
 	Type                string `json:"type"`
-	VCenterInstanceUuid string `json:"vCenterInstanceUuid"`
+	VCenterInstanceUUID string `json:"vCenterInstanceUuid"`
 	VCenterName         string `json:"vCenterName,omitempty"`
 }
 
 type IPScope struct {
-	DnsSuffix       string           `json:"dnsSuffix,omitempty"`
+	DNSSuffix       string           `json:"dnsSuffix,omitempty"`
 	Gateway         string           `json:"gateway,omitempty"`
 	PrefixLength    int              `json:"prefixLength"`
-	PrimaryDns      string           `json:"primaryDns,omitempty"`
-	SecondaryDns    string           `json:"secondaryDns,omitempty"`
-	NetworkIpRanges []NetworkIpRange `json:"networkIpRanges,omitempty"`
+	PrimaryDNS      string           `json:"primaryDns,omitempty"`
+	SecondaryDNS    string           `json:"secondaryDns,omitempty"`
+	NetworkIPRanges []NetworkIPRange `json:"networkIpRanges,omitempty"`
 	PoolID          string           `json:"poolId"`
 }
 
-type NetworkIpRange struct {
+type NetworkIPRange struct {
 	EndAddress   string `json:"endAddress"`
 	StartAddress string `json:"startAddress"`
 }
@@ -65,7 +65,7 @@ type NetworkProfileResult struct {
 
 type NetworkProfileData struct {
 	JobID    string `json:"jobId"`
-	ObjectId string `json:"objectId"`
+	ObjectID string `json:"objectId"`
 }
 
 // InsertNetworkProfile ...
@@ -150,8 +150,8 @@ func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
 	return NetworkProfileBody{}, errors.New("cannot find network profile")
 }
 
-// GetNetworkProfileById ...
-func GetNetworkProfileById(c *Client, id string) (NetworkProfileBody, error) {
+// GetNetworkProfileByID ...
+func GetNetworkProfileByID(c *Client, id string) (NetworkProfileBody, error) {
 
 	resp := []NetworkProfileBody{}
 	body := NetworkFilter{
@@ -189,7 +189,7 @@ func GetNetworkProfileById(c *Client, id string) (NetworkProfileBody, error) {
 	}
 
 	for _, j := range resp {
-		if j.ObjectId == id {
+		if j.ObjectID == id {
 			return j, nil
 		}
 	}
@@ -237,7 +237,7 @@ func UpdateNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 		return resp, err
 	}
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectId), &buf)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectID), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/role_mapping.go
+++ b/hcx/role_mapping.go
@@ -19,7 +19,7 @@ type RoleMapping struct {
 type RoleMappingResult struct {
 	IsSuccess      bool   `json:"isSuccess"`
 	Message        string `json:"message"`
-	HttpStatusCode int    `json:"httpStatusCode"`
+	HTTPStatusCode int    `json:"httpStatusCode"`
 }
 
 // PostActivate ...

--- a/hcx/service_mesh.go
+++ b/hcx/service_mesh.go
@@ -12,9 +12,9 @@ import (
 )
 
 type ComputeProfile struct {
-	ComputeProfileId   string `json:"computeProfileId"`
+	ComputeProfileID   string `json:"computeProfileId"`
 	ComputeProfileName string `json:"computeProfileName"`
-	EndpointId         string `json:"endpointId"`
+	EndpointID         string `json:"endpointId"`
 	EndpointName       string `json:"endpointName"`
 }
 
@@ -24,7 +24,7 @@ type WanoptConfig struct {
 
 type TrafficEnggCfg struct {
 	IsAppPathResiliencyEnabled   bool `json:"isAppPathResiliencyEnabled"`
-	IsTcpFlowConditioningEnabled bool `json:"isTcpFlowConditioningEnabled"`
+	IsTCPFlowConditioningEnabled bool `json:"isTcpFlowConditioningEnabled"`
 }
 
 type SwitchPairCount struct {
@@ -46,8 +46,8 @@ type InsertServiceMeshResult struct {
 }
 
 type InsertServiceMeshData struct {
-	InterconnectTaskId string `json:"interconnectTaskId"`
-	ServiceMeshId      string `json:"serviceMeshId"`
+	InterconnectID string `json:"interconnectTaskId"`
+	ServiceMeshID  string `json:"serviceMeshId"`
 }
 
 type DeleteServiceMeshResult struct {
@@ -55,8 +55,8 @@ type DeleteServiceMeshResult struct {
 }
 
 type DeleteServiceMeshData struct {
-	InterconnectTaskId string `json:"interconnectTaskId"`
-	ServiceMeshId      string `json:"serviceMeshId"`
+	InterconnectTaskID string `json:"interconnectTaskId"`
+	ServiceMeshID      string `json:"serviceMeshId"`
 }
 
 // InsertServiceMesh ...

--- a/hcx/site_pairing.go
+++ b/hcx/site_pairing.go
@@ -11,16 +11,16 @@ import (
 	"net/http"
 )
 
-type Remote_data struct {
+type RemoteData struct {
 	Username   string `json:"username"`
 	Password   string `json:"password"`
 	URL        string `json:"url"`
-	EndpointId string `json:"endpointId,omitempty"`
+	EndpointID string `json:"endpointId,omitempty"`
 	CloudType  string `json:"cloudType,omitempty"`
 }
 
 type RemoteCloudConfigBody struct {
-	Remote Remote_data `json:"remote"`
+	Remote RemoteData `json:"remote"`
 }
 
 type PostRemoteCloudConfigResultData struct {
@@ -51,7 +51,7 @@ type GetRemoteCloudConfigResult struct {
 }
 
 type GetRemoteCloudConfigResultData struct {
-	Items []Remote_data `json:"items"`
+	Items []RemoteData `json:"items"`
 }
 
 type DeleteRemoteCloudConfigResult struct {
@@ -124,11 +124,11 @@ func GetSitePairings(c *Client) (GetRemoteCloudConfigResult, error) {
 }
 
 // DeleteSitePairings ...
-func DeleteSitePairings(c *Client, endpointId string) (DeleteRemoteCloudConfigResult, error) {
+func DeleteSitePairings(c *Client, endpointID string) (DeleteRemoteCloudConfigResult, error) {
 
 	resp := DeleteRemoteCloudConfigResult{}
 
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/endpointPairing/%s", c.HostURL, endpointId), nil)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/endpointPairing/%s", c.HostURL, endpointID), nil)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/sso.go
+++ b/hcx/sso.go
@@ -24,7 +24,7 @@ type InsertSSODataItem struct {
 }
 
 type InsertSSODataItemConfig struct {
-	LookupServiceUrl string `json:"lookupServiceUrl"`
+	LookupServiceURL string `json:"lookupServiceUrl"`
 	ProviderType     string `json:"providerType"`
 	UUID             string `json:"UUID,omitempty"`
 }

--- a/hcx/utils.go
+++ b/hcx/utils.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 )
 
-type Job_result struct {
+type JobResult struct {
 	JobID                   string `json:"jobId"`
 	Enterprise              string `json:"enterprise"`
 	Organization            string `json:"organization"`
@@ -31,47 +31,47 @@ type Job_result struct {
 	TimeToExecute           int64  `json:"timeToExecute"`
 }
 
-type Task_result struct {
-	InterconnectTaskId string `json:"interconnectTaskId"`
+type TaskResult struct {
+	InterconnectTaskID string `json:"interconnectTaskId"`
 	Status             string `json:"status"`
 }
 
-type ResouceContainerListFilterCloud struct {
+type ResourceContainerListFilterCloud struct {
 	Local  bool `json:"local"`
 	Remote bool `json:"remote"`
 }
 
-type ResouceContainerListFilter struct {
-	Cloud ResouceContainerListFilterCloud `json:"cloud"`
+type ResourceContainerListFilter struct {
+	Cloud ResourceContainerListFilterCloud `json:"cloud"`
 }
 
-type PostResouceContainerListBody struct {
-	Filter ResouceContainerListFilter `json:"filter"`
+type PostResourceContainerListBody struct {
+	Filter ResourceContainerListFilter `json:"filter"`
 }
 
-type PostResouceContainerListResult struct {
-	Success   bool                               `json:"success"`
-	Completed bool                               `json:"completed"`
-	Time      int64                              `json:"time"`
-	Data      PostResouceContainerListResultData `json:"data"`
+type PostResourceContainerListResult struct {
+	Success   bool                                `json:"success"`
+	Completed bool                                `json:"completed"`
+	Time      int64                               `json:"time"`
+	Data      PostResourceContainerListResultData `json:"data"`
 }
 
-type PostResouceContainerListResultData struct {
-	Items []PostResouceContainerListResultDataItem `json:"items"`
+type PostResourceContainerListResultData struct {
+	Items []PostResourceContainerListResultDataItem `json:"items"`
 }
 
-type PostResouceContainerListResultDataItem struct {
+type PostResourceContainerListResultDataItem struct {
 	URL           string `json:"url"`
-	Vcuuid        string `json:"vcuuid"`
+	VcUUID        string `json:"vcuuid"`
 	Version       string `json:"version"`
 	BuildNumber   string `json:"buildNumber"`
 	OsType        string `json:"osType"`
 	Name          string `json:"name"`
-	ResourceId    string `json:"resourceId"`
+	ResourceID    string `json:"resourceId"`
 	ResourceType  string `json:"resourceType"`
 	ResourceName  string `json:"resourceName"`
-	VimId         string `json:"vimId"`
-	VimServerUuid string `json:"vimServerUuid"`
+	VimID         string `json:"vimId"`
+	VimServerUUID string `json:"vimServerUuid"`
 }
 
 type PostNetworkBackingBody struct {
@@ -80,7 +80,7 @@ type PostNetworkBackingBody struct {
 
 type PostNetworkBackingBodyFilter struct {
 	Cloud PostCloudListResultDataItem `json:"cloud"`
-	//VCenterInstanceUuid string   `json:"vCenterInstanceUuid"`
+	//VCenterInstanceUUID string   `json:"vCenterInstanceUuid"`
 	//ExcludeUsed         bool     `json:"excludeUsed"`
 	//BackingTypes        []string `json:"backingTypes"`
 }
@@ -108,26 +108,26 @@ type GetVcInventoryResultData struct {
 }
 
 type GetVcInventoryResultDataItem struct {
-	Vcenter_instanceId string                                 `json:"vcenter_instanceId"`
-	Entity_id          string                                 `json:"entity_id"`
-	Children           []GetVcInventoryResultDataItemChildren `json:"children"`
-	Name               string                                 `json:"name"`
-	EntityType         string                                 `json:"entityType"`
+	VCenterInstanceID string                                 `json:"vcenter_instanceId"`
+	EntityID          string                                 `json:"entity_id"`
+	Children          []GetVcInventoryResultDataItemChildren `json:"children"`
+	Name              string                                 `json:"name"`
+	EntityType        string                                 `json:"entityType"`
 }
 
 type GetVcInventoryResultDataItemChildren struct {
-	Vcenter_instanceId string                                         `json:"vcenter_instanceId"`
-	Entity_id          string                                         `json:"entity_id"`
-	Children           []GetVcInventoryResultDataItemChildrenChildren `json:"children"`
-	Name               string                                         `json:"name"`
-	EntityType         string                                         `json:"entityType"`
+	VCenterInstanceID string                                         `json:"vcenter_instanceId"`
+	EntityID          string                                         `json:"entity_id"`
+	Children          []GetVcInventoryResultDataItemChildrenChildren `json:"children"`
+	Name              string                                         `json:"name"`
+	EntityType        string                                         `json:"entityType"`
 }
 
 type GetVcInventoryResultDataItemChildrenChildren struct {
-	Vcenter_instanceId string `json:"vcenter_instanceId"`
-	Entity_id          string `json:"entity_id"`
-	Name               string `json:"name"`
-	EntityType         string `json:"entityType"`
+	VCenterInstanceID string `json:"vcenter_instanceId"`
+	EntityID          string `json:"entity_id"`
+	Name              string `json:"name"`
+	EntityType        string `json:"entityType"`
 	// Datastores
 }
 
@@ -155,7 +155,7 @@ type GetVcDatastoreBody struct {
 type GetVcDatastoreFilter struct {
 	ComputeType       string   `json:"computeType"`
 	VCenterInstanceID string   `json:"vcenter_instanceId"`
-	ComputeIds        []string `json:"computeIds"`
+	ComputeIDs        []string `json:"computeIds"`
 }
 
 type GetVcDvsResult struct {
@@ -173,7 +173,7 @@ type GetVcDvsResultDataItem struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`
 	Type   string `json:"type"`
-	MaxMtu int    `json:"maxMtu"`
+	MaxMTU int    `json:"maxMtu"`
 }
 
 type GetVcDvsBody struct {
@@ -183,7 +183,7 @@ type GetVcDvsBody struct {
 type GetVcDvsFilter struct {
 	ComputeType       string   `json:"computeType"`
 	VCenterInstanceID string   `json:"vcenter_instanceId"`
-	ComputeIds        []string `json:"computeIds"`
+	ComputeIDs        []string `json:"computeIds"`
 }
 
 type PostCloudListFilter struct {
@@ -207,7 +207,7 @@ type PostCloudListResultData struct {
 }
 
 type PostCloudListResultDataItem struct {
-	EndpointId   string `json:"endpointId,omitempty"`
+	EndpointID   string `json:"endpointId,omitempty"`
 	Name         string `json:"name,omitempty"`
 	URL          string `json:"url,omitempty"`
 	EndpointType string `json:"endpointType,omitempty"`
@@ -219,8 +219,8 @@ type GetApplianceBody struct {
 
 type GetApplianceBodyFilter struct {
 	ApplianceType string `json:"applianceType"`
-	EndpointId    string `json:"endpointId"`
-	ServiceMeshId string `json:"serviceMeshId,omitempty"`
+	EndpointID    string `json:"endpointId"`
+	ServiceMeshID string `json:"serviceMeshId,omitempty"`
 }
 
 type GetApplianceResult struct {
@@ -228,17 +228,17 @@ type GetApplianceResult struct {
 }
 
 type GetApplianceResultItem struct {
-	ApplianceId           string `json:"applianceId"`
-	ServiceMeshId         string `json:"serviceMeshId"`
+	ApplianceID           string `json:"applianceId"`
+	ServiceMeshID         string `json:"serviceMeshId"`
 	NetworkExtensionCount int    `json:"networkExtensionCount"`
 }
 
 // GetJobResult ...
-func GetJobResult(c *Client, jobId string) (Job_result, error) {
+func GetJobResult(c *Client, jobID string) (JobResult, error) {
 
-	resp := Job_result{}
+	resp := JobResult{}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/jobs/%s", c.HostURL, jobId), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/jobs/%s", c.HostURL, jobID), nil)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err
@@ -262,11 +262,11 @@ func GetJobResult(c *Client, jobId string) (Job_result, error) {
 }
 
 // GetTaskResult ...
-func GetTaskResult(c *Client, taskId string) (Task_result, error) {
+func GetTaskResult(c *Client, taskID string) (TaskResult, error) {
 
-	resp := Task_result{}
+	resp := TaskResult{}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/tasks/%s", c.HostURL, taskId), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/tasks/%s", c.HostURL, taskID), nil)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err
@@ -290,11 +290,11 @@ func GetTaskResult(c *Client, taskId string) (Task_result, error) {
 }
 
 // GetLocalConatainer ...
-func GetLocalContainer(c *Client) (PostResouceContainerListResultDataItem, error) {
+func GetLocalContainer(c *Client) (PostResourceContainerListResultDataItem, error) {
 
-	body := PostResouceContainerListBody{
-		Filter: ResouceContainerListFilter{
-			Cloud: ResouceContainerListFilterCloud{
+	body := PostResourceContainerListBody{
+		Filter: ResourceContainerListFilter{
+			Cloud: ResourceContainerListFilterCloud{
 				Local:  true,
 				Remote: false,
 			},
@@ -308,37 +308,37 @@ func GetLocalContainer(c *Client) (PostResouceContainerListResultDataItem, error
 		return PostResouceContainerListResultDataItem{}, err
 	}
 
-	resp := PostResouceContainerListResult{}
+	resp := PostResourceContainerListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	// Send the request
 	_, r, err := c.doRequest(req)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	// parse response body
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	return resp.Data.Items[0], nil
 }
 
 // GetLocalConatainer ...
-func GetRemoteContainer(c *Client) (PostResouceContainerListResultDataItem, error) {
+func GetRemoteContainer(c *Client) (PostResourceContainerListResultDataItem, error) {
 
-	body := PostResouceContainerListBody{
-		Filter: ResouceContainerListFilter{
-			Cloud: ResouceContainerListFilterCloud{
+	body := PostResourceContainerListBody{
+		Filter: ResourceContainerListFilter{
+			Cloud: ResourceContainerListFilterCloud{
 				Local:  false,
 				Remote: true,
 			},
@@ -352,38 +352,38 @@ func GetRemoteContainer(c *Client) (PostResouceContainerListResultDataItem, erro
 		return PostResouceContainerListResultDataItem{}, err
 	}
 
-	resp := PostResouceContainerListResult{}
+	resp := PostResourceContainerListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	// Send the request
 	_, r, err := c.doRequest(req)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	// parse response body
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
 		fmt.Println(err)
-		return PostResouceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, err
 	}
 
 	return resp.Data.Items[0], nil
 }
 
 // GetNetworkBacking ...
-func GetNetworkBacking(c *Client, endpointid string, network string, network_type string) (Dvpg, error) {
+func GetNetworkBacking(c *Client, endpointID string, network string, networkType string) (Dvpg, error) {
 
 	body := PostNetworkBackingBody{
 		Filter: PostNetworkBackingBodyFilter{
 			Cloud: PostCloudListResultDataItem{
-				EndpointId: endpointid,
+				EndpointID: endpointID,
 			},
 		},
 	}
@@ -422,7 +422,7 @@ func GetNetworkBacking(c *Client, endpointid string, network string, network_typ
 	log.Printf("*************************************")
 
 	for _, j := range resp.Data.Items {
-		if j.Name == network && j.EntityType == network_type {
+		if j.Name == network && j.EntityType == networkType {
 			return j, nil
 		}
 	}
@@ -462,13 +462,13 @@ func GetVcInventory(c *Client) (GetVcInventoryResultDataItem, error) {
 }
 
 // GetVcDatastore ...
-func GetVcDatastore(c *Client, datastore_name string, vcuuid string, cluster string) (GetVcDatastoreResultDataItem, error) {
+func GetVcDatastore(c *Client, datastoreName string, vcuuid string, cluster string) (GetVcDatastoreResultDataItem, error) {
 
 	body := GetVcDatastoreBody{
 		Filter: GetVcDatastoreFilter{
 			VCenterInstanceID: vcuuid,
 			ComputeType:       "ClusterComputeResource",
-			ComputeIds:        []string{cluster},
+			ComputeIDs:        []string{cluster},
 		},
 	}
 
@@ -502,7 +502,7 @@ func GetVcDatastore(c *Client, datastore_name string, vcuuid string, cluster str
 	}
 
 	for _, j := range resp.Data.Items {
-		if j.Name == datastore_name {
+		if j.Name == datastoreName {
 			return j, nil
 		}
 	}
@@ -511,13 +511,13 @@ func GetVcDatastore(c *Client, datastore_name string, vcuuid string, cluster str
 }
 
 // GetVcDvs ...
-func GetVcDvs(c *Client, dvs_name string, vcuuid string, cluster string) (GetVcDvsResultDataItem, error) {
+func GetVcDvs(c *Client, dvsName string, vcuuid string, cluster string) (GetVcDvsResultDataItem, error) {
 
 	body := GetVcDvsBody{
 		Filter: GetVcDvsFilter{
 			VCenterInstanceID: vcuuid,
 			ComputeType:       "ClusterComputeResource",
-			ComputeIds:        []string{cluster},
+			ComputeIDs:        []string{cluster},
 		},
 	}
 
@@ -551,7 +551,7 @@ func GetVcDvs(c *Client, dvs_name string, vcuuid string, cluster string) (GetVcD
 	}
 
 	for _, j := range resp.Data.Items {
-		if j.Name == dvs_name {
+		if j.Name == dvsName {
 			return j, nil
 		}
 	}
@@ -642,12 +642,12 @@ func GetLocalCloudList(c *Client) (PostCloudListResult, error) {
 }
 
 // GetRemoteCloudList ...
-func GetAppliance(c *Client, endpointId string, service_mesh_id string) (GetApplianceResultItem, error) {
+func GetAppliance(c *Client, endpointID string, serviceMeshID string) (GetApplianceResultItem, error) {
 
 	body := GetApplianceBody{
 		Filter: GetApplianceBodyFilter{
 			ApplianceType: "HCX-NET-EXT",
-			EndpointId:    endpointId,
+			EndpointID:    endpointID,
 		},
 	}
 
@@ -681,7 +681,7 @@ func GetAppliance(c *Client, endpointId string, service_mesh_id string) (GetAppl
 	}
 
 	for _, j := range resp.Items {
-		if j.ServiceMeshId == service_mesh_id && j.NetworkExtensionCount < 9 {
+		if j.ServiceMeshID == serviceMeshID && j.NetworkExtensionCount < 9 {
 			return j, nil
 		}
 	}
@@ -690,13 +690,13 @@ func GetAppliance(c *Client, endpointId string, service_mesh_id string) (GetAppl
 }
 
 // GetRemoteCloudList ...
-func GetAppliances(c *Client, endpointId string, service_mesh_id string) ([]GetApplianceResultItem, error) {
+func GetAppliances(c *Client, endpointID string, serviceMeshID string) ([]GetApplianceResultItem, error) {
 
 	body := GetApplianceBody{
 		Filter: GetApplianceBodyFilter{
 			ApplianceType: "HCX-NET-EXT",
-			EndpointId:    endpointId,
-			ServiceMeshId: service_mesh_id,
+			EndpointID:    endpointID,
+			ServiceMeshID: serviceMeshID,
 		},
 	}
 

--- a/hcx/vcenter.go
+++ b/hcx/vcenter.go
@@ -27,7 +27,7 @@ type InsertvCenterDataItemConfig struct {
 	URL      string `json:"url"`
 	Username string `json:"userName"`
 	Password string `json:"password"`
-	Vcuuid   string `json:"vcuuid,omitempty"`
+	VcUUID   string `json:"vcuuid,omitempty"`
 	UUID     string `json:"UUID,omitempty"`
 }
 

--- a/hcx/vmc.go
+++ b/hcx/vmc.go
@@ -132,7 +132,7 @@ func CloudAuthenticate(client *Client, token string) error {
 
 }
 
-func GetSddcByName(client *Client, sddc_name string) (SDDC, error) {
+func GetSddcByName(client *Client, sddcName string) (SDDC, error) {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
@@ -159,7 +159,7 @@ func GetSddcByName(client *Client, sddc_name string) (SDDC, error) {
 	}
 
 	for _, j := range resp.SDDCs {
-		if j.Name == sddc_name {
+		if j.Name == sddcName {
 			return j, nil
 		}
 	}
@@ -206,7 +206,7 @@ func GetSddcByID(client *Client, sddcID string) (SDDC, error) {
 
 }
 
-func ActivateHcxOnSDDC(client *Client, sddc_id string) (ActivateHcxOnSDDCResults, error) {
+func ActivateHcxOnSDDC(client *Client, sddcID string) (ActivateHcxOnSDDCResults, error) {
 
 	resp := ActivateHcxOnSDDCResults{}
 
@@ -216,7 +216,7 @@ func ActivateHcxOnSDDC(client *Client, sddc_id string) (ActivateHcxOnSDDCResults
 		HcxToken:   client.HcxToken,
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sddcs/%s?action=activate", c.HostURL, sddc_id), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sddcs/%s?action=activate", c.HostURL, sddcID), nil)
 	if err != nil {
 		return resp, err
 	}
@@ -238,7 +238,7 @@ func ActivateHcxOnSDDC(client *Client, sddc_id string) (ActivateHcxOnSDDCResults
 
 }
 
-func DeactivateHcxOnSDDC(client *Client, sddc_id string) (DeactivateHcxOnSDDCResults, error) {
+func DeactivateHcxOnSDDC(client *Client, sddcID string) (DeactivateHcxOnSDDCResults, error) {
 
 	resp := DeactivateHcxOnSDDCResults{}
 
@@ -248,7 +248,7 @@ func DeactivateHcxOnSDDC(client *Client, sddc_id string) (DeactivateHcxOnSDDCRes
 		HcxToken:   client.HcxToken,
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sddcs/%s?action=deactivate", c.HostURL, sddc_id), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sddcs/%s?action=deactivate", c.HostURL, sddcID), nil)
 	if err != nil {
 		return resp, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -81,21 +81,21 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	hcxurl := d.Get("hcx").(string)
+	hcxURL := d.Get("hcx").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
-	adminusername := d.Get("admin_username").(string)
-	adminpassword := d.Get("admin_password").(string)
-	vmc_token := d.Get("vmc_token").(string)
+	adminUsername := d.Get("admin_username").(string)
+	adminPassword := d.Get("admin_password").(string)
+	vmcToken := d.Get("vmc_token").(string)
 
-	c, err := hcx.NewClient(&hcxurl, &username, &password, &adminusername, &adminpassword, &vmc_token)
+	c, err := hcx.NewClient(&hcxURL, &username, &password, &adminUsername, &adminPassword, &vmcToken)
 	//c := &http.Client{Timeout: 10 * time.Second}
 
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
 
-	if hcxurl == "" {
+	if hcxURL == "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity:      diag.Warning,
 			Summary:       "No HCX Url provided",
@@ -104,7 +104,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		})
 	}
 
-	c.Token = vmc_token
+	c.Token = vmcToken
 
 	return c, diags
 }

--- a/resource_compute_profile.go
+++ b/resource_compute_profile.go
@@ -103,13 +103,13 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// Get Cluster info
-	var cluster_id string
-	var cluster_name string
+	var clusterID string
+	var clusterName string
 	found := false
 	for _, j := range res.Children[0].Children {
 		if j.Name == cluster {
-			cluster_id = j.Entity_id
-			cluster_name = j.Name
+			clusterID = j.EntityID
+			clusterName = j.Name
 			found = true
 		}
 	}
@@ -119,182 +119,182 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// Get Datastore info
 	datastore := d.Get("datastore").(string)
-	datastore_from_api, err := hcx.GetVcDatastore(client, datastore, res.Entity_id, cluster_id)
+	datastoreFromAPI, err := hcx.GetVcDatastore(client, datastore, res.EntityID, clusterID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Get DVS info
 	dvs := d.Get("dvs").(string)
-	dvs_from_api, err := hcx.GetVcDvs(client, dvs, res.Entity_id, cluster_id)
+	dvsFromAPI, err := hcx.GetVcDvs(client, dvs, res.EntityID, clusterID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Get Services from schema
 	services := d.Get("service").([]interface{})
-	services_from_schema := []hcx.Service{}
+	servicesFromSchema := []hcx.Service{}
 	for _, j := range services {
 		s := j.(map[string]interface{})
 		name := s["name"].(string)
 
-		s_tmp := hcx.Service{
+		sTmp := hcx.Service{
 			Name: name,
 		}
-		services_from_schema = append(services_from_schema, s_tmp)
+		servicesFromSchema = append(servicesFromSchema, sTmp)
 	}
 
 	// Create network list with tags
-	management_network := d.Get("management_network").(string)
-	replication_network := d.Get("replication_network").(string)
-	uplink_network := d.Get("uplink_network").(string)
-	vmotion_network := d.Get("vmotion_network").(string)
+	managementNetwork := d.Get("management_network").(string)
+	replicationNetwork := d.Get("replication_network").(string)
+	uplinkNetwork := d.Get("uplink_network").(string)
+	vmotionNetwork := d.Get("vmotion_network").(string)
 
-	networks_list := []hcx.Network{}
-	np, err := hcx.GetNetworkProfileById(client, management_network)
+	networksList := []hcx.Network{}
+	np, err := hcx.GetNetworkProfileByID(client, managementNetwork)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	management_network_name := np.Name
-	management_network_id := np.ObjectId
+	managementNetworkName := np.Name
+	managementNetworkID := np.ObjectID
 
-	np, err = hcx.GetNetworkProfileById(client, replication_network)
+	np, err = hcx.GetNetworkProfileByID(client, replicationNetwork)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	replication_network_name := np.Name
-	replication_network_id := np.ObjectId
+	replicationNetworkName := np.Name
+	replicationNetworkID := np.ObjectID
 
-	np, err = hcx.GetNetworkProfileById(client, uplink_network)
+	np, err = hcx.GetNetworkProfileByID(client, uplinkNetwork)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	uplink_network_name := np.Name
-	uplink_network_id := np.ObjectId
+	uplinkNetworkName := np.Name
+	uplinkNetworkID := np.ObjectID
 
-	np, err = hcx.GetNetworkProfileById(client, vmotion_network)
+	np, err = hcx.GetNetworkProfileByID(client, vmotionNetwork)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	vmotion_network_name := np.Name
-	vmotion_network_id := np.ObjectId
+	vmotionNetworkName := np.Name
+	vmotionNetworkID := np.ObjectID
 
-	net_tmp := hcx.Network{
-		Name: management_network_name,
-		ID:   management_network_id,
+	netTmp := hcx.Network{
+		Name: managementNetworkName,
+		ID:   managementNetworkID,
 		Tags: []string{"management"},
 		Status: hcx.Status{
 			State: "REALIZED",
 		},
 	}
-	networks_list = append(networks_list, net_tmp)
+	networksList = append(networksList, netTmp)
 
 	found = false
 	index := 0
-	for i, j := range networks_list {
-		if j.Name == replication_network_name {
+	for i, j := range networksList {
+		if j.Name == replicationNetworkName {
 			found = true
 			index = i
 			break
 		}
 	}
 	if found {
-		networks_list[index].Tags = append(networks_list[index].Tags, "replication")
+		networksList[index].Tags = append(networksList[index].Tags, "replication")
 	} else {
-		net_tmp := hcx.Network{
-			Name: replication_network_name,
-			ID:   replication_network_id,
+		netTmp := hcx.Network{
+			Name: replicationNetworkName,
+			ID:   replicationNetworkID,
 			Tags: []string{"replication"},
 			Status: hcx.Status{
 				State: "REALIZED",
 			},
 		}
-		networks_list = append(networks_list, net_tmp)
+		networksList = append(networksList, netTmp)
 	}
 
 	found = false
 	index = 0
-	for i, j := range networks_list {
-		if j.Name == uplink_network_name {
+	for i, j := range networksList {
+		if j.Name == uplinkNetworkName {
 			found = true
 			index = i
 			break
 		}
 	}
 	if found {
-		networks_list[index].Tags = append(networks_list[index].Tags, "uplink")
+		networksList[index].Tags = append(networksList[index].Tags, "uplink")
 	} else {
-		net_tmp := hcx.Network{
-			Name: uplink_network_name,
-			ID:   uplink_network_id,
+		netTmp := hcx.Network{
+			Name: uplinkNetworkName,
+			ID:   uplinkNetworkID,
 			Tags: []string{"uplink"},
 			Status: hcx.Status{
 				State: "REALIZED",
 			},
 		}
-		networks_list = append(networks_list, net_tmp)
+		networksList = append(networksList, netTmp)
 	}
 
 	found = false
 	index = 0
-	for i, j := range networks_list {
-		if j.Name == vmotion_network_name {
+	for i, j := range networksList {
+		if j.Name == vmotionNetworkName {
 			found = true
 			index = i
 			break
 		}
 	}
 	if found {
-		networks_list[index].Tags = append(networks_list[index].Tags, "vmotion")
+		networksList[index].Tags = append(networksList[index].Tags, "vmotion")
 	} else {
-		net_tmp := hcx.Network{
-			Name: vmotion_network_name,
-			ID:   vmotion_network_id,
+		netTmp := hcx.Network{
+			Name: vmotionNetworkName,
+			ID:   vmotionNetworkID,
 			Tags: []string{"vmotion"},
 			Status: hcx.Status{
 				State: "REALIZED",
 			},
 		}
-		networks_list = append(networks_list, net_tmp)
+		networksList = append(networksList, netTmp)
 	}
 
 	body := hcx.InsertComputeProfileBody{
 		Name:     name,
-		Services: services_from_schema,
+		Services: servicesFromSchema,
 		Computes: []hcx.Compute{{
-			CmpId:   res.Entity_id,
-			CmpType: "VC",
-			CmpName: res.Name,
-			ID:      res.Children[0].Entity_id,
-			Name:    res.Children[0].Name,
-			Type:    res.Children[0].EntityType,
+			ComputeID:   res.EntityID,
+			ComputeType: "VC",
+			ComputeName: res.Name,
+			ID:          res.Children[0].EntityID,
+			Name:        res.Children[0].Name,
+			Type:        res.Children[0].EntityType,
 		}},
 		DeploymentContainers: hcx.DeploymentContainer{
 			Computes: []hcx.Compute{{
-				CmpId:   res.Entity_id,
-				CmpType: "VC",
-				CmpName: res.Name,
-				ID:      cluster_id,
-				Name:    cluster_name,
-				Type:    "ClusterComputeResource",
+				ComputeID:   res.EntityID,
+				ComputeType: "VC",
+				ComputeName: res.Name,
+				ID:          clusterID,
+				Name:        clusterName,
+				Type:        "ClusterComputeResource",
 			},
 			},
 			Storage: []hcx.Storage{{
-				CmpId:   res.Entity_id,
-				CmpType: "VC",
-				CmpName: res.Name,
-				ID:      datastore_from_api.ID,
-				Name:    datastore_from_api.Name,
-				Type:    datastore_from_api.EntityType,
+				ComputeID:   res.EntityID,
+				ComputeType: "VC",
+				ComputeName: res.Name,
+				ID:          datastoreFromAPI.ID,
+				Name:        datastoreFromAPI.Name,
+				Type:        datastoreFromAPI.EntityType,
 			}},
 		},
-		Networks: networks_list,
+		Networks: networksList,
 		Switches: []hcx.Switch{{
-			CmpID:  res.Entity_id,
-			MaxMTU: dvs_from_api.MaxMtu,
-			ID:     dvs_from_api.ID,
-			Name:   dvs_from_api.Name,
-			Type:   dvs_from_api.Type,
+			ComputeID: res.EntityID,
+			MaxMTU:    dvsFromAPI.MaxMTU,
+			ID:        dvsFromAPI.ID,
+			Name:      dvsFromAPI.Name,
+			Type:      dvsFromAPI.Type,
 		}},
 	}
 
@@ -310,7 +310,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// Wait for task completion
 	for {
-		jr, err := hcx.GetTaskResult(client, res2.Data.InterconnectTaskId)
+		jr, err := hcx.GetTaskResult(client, res2.Data.InterconnectTaskID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -326,7 +326,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		time.Sleep(5 * time.Second)
 	}
 
-	d.SetId(res2.Data.ComputeProfileId)
+	d.SetId(res2.Data.ComputeProfileID)
 
 	return resourceComputeProfileRead(ctx, d, m)
 
@@ -355,7 +355,7 @@ func resourceComputeProfileDelete(ctx context.Context, d *schema.ResourceData, m
 
 	// Wait for task completion
 	for {
-		jr, err := hcx.GetTaskResult(client, res.Data.InterconnectTaskId)
+		jr, err := hcx.GetTaskResult(client, res.Data.InterconnectTaskID)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/resource_l2_extension.go
+++ b/resource_l2_extension.go
@@ -87,72 +87,72 @@ func resourceL2ExtensionCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	client := m.(*hcx.Client)
 
-	site_pairing := d.Get("site_pairing").(map[string]interface{})
-	vcGuid := site_pairing["local_vc"].(string)
+	sitePairing := d.Get("site_pairing").(map[string]interface{})
+	vcGUID := sitePairing["local_vc"].(string)
 
 	//service_mesh := d.Get("service_mesh").(map[string]interface{})
-	source_network := d.Get("source_network").(string)
-	destination_t1 := d.Get("destination_t1").(string)
+	sourceNetwork := d.Get("source_network").(string)
+	destinationT1 := d.Get("destination_t1").(string)
 	gateway := d.Get("gateway").(string)
 	netmask := d.Get("netmask").(string)
 
-	destination_endpoint_id := site_pairing["id"].(string)
-	destination_endpoint_name := site_pairing["remote_name"].(string)
-	destination_endpoint_type := site_pairing["remote_endpoint_type"].(string)
+	destinationEndpointID := sitePairing["id"].(string)
+	destinationEndpointName := sitePairing["remote_name"].(string)
+	destinationEndpointType := sitePairing["remote_endpoint_type"].(string)
 
-	destination_resource_id := site_pairing["remote_resource_id"].(string)
-	destination_resource_name := site_pairing["remote_resource_name"].(string)
-	destination_resource_type := site_pairing["remote_resource_type"].(string)
+	destinationResourceID := sitePairing["remote_resource_id"].(string)
+	destinationResourceName := sitePairing["remote_resource_name"].(string)
+	destinationResourceType := sitePairing["remote_resource_type"].(string)
 
 	mon := d.Get("mon").(bool)
-	egress_optimization := d.Get("egress_optimization").(bool)
+	egressOptimization := d.Get("egress_optimization").(bool)
 
-	network_type := d.Get("network_type").(string)
+	networkType := d.Get("network_type").(string)
 
-	service_mesh_id := d.Get("service_mesh_id").(string)
+	serviceMeshID := d.Get("service_mesh_id").(string)
 
-	dvpg, err := hcx.GetNetworkBacking(client, site_pairing["local_endpoint_id"].(string), source_network, network_type)
+	dvpg, err := hcx.GetNetworkBacking(client, sitePairing["local_endpoint_id"].(string), sourceNetwork, networkType)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	appliance_id := d.Get("appliance_id").(string)
-	if appliance_id == "" {
+	applianceID := d.Get("appliance_id").(string)
+	if applianceID == "" {
 		// GET THE FIRST APPLIANCE
-		appliance, err := hcx.GetAppliance(client, site_pairing["local_endpoint_id"].(string), service_mesh_id)
+		appliance, err := hcx.GetAppliance(client, sitePairing["local_endpoint_id"].(string), serviceMeshID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		appliance_id = appliance.ApplianceId
+		applianceID = appliance.ApplianceID
 	}
 
 	body := hcx.InsertL2ExtensionBody{
 		Gateway: gateway,
 		Netmask: netmask,
 		DestinationNetwork: hcx.DestinationNetwork{
-			GatewayId: destination_t1,
+			GatewayID: destinationT1,
 		},
-		Dns: []string{},
+		DNS: []string{},
 		Features: hcx.Features{
-			EgressOptimization: egress_optimization,
+			EgressOptimization: egressOptimization,
 			Mon:                mon,
 		},
 		SourceAppliance: hcx.SourceAppliance{
-			ApplianceId: appliance_id,
+			ApplianceID: applianceID,
 		},
 		SourceNetwork: hcx.SourceNetwork{
-			NetworkId:   dvpg.EntityID,
+			NetworkID:   dvpg.EntityID,
 			NetworkName: dvpg.Name,
 			NetworkType: dvpg.EntityType,
 		},
-		VcGuid: vcGuid,
+		VcGUID: vcGUID,
 		Destination: hcx.Destination{
-			EndpointId:   destination_endpoint_id,
-			EndpointName: destination_endpoint_name,
-			EndpointType: destination_endpoint_type,
-			ResourceId:   destination_resource_id,
-			ResourceName: destination_resource_name,
-			ResourceType: destination_resource_type,
+			EndpointID:   destinationEndpointID,
+			EndpointName: destinationEndpointName,
+			EndpointType: destinationEndpointType,
+			ResourceID:   destinationResourceID,
+			ResourceName: destinationResourceName,
+			ResourceType: destinationResourceType,
 		},
 	}
 
@@ -186,7 +186,7 @@ func resourceL2ExtensionCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	d.SetId(res3.StretchId)
+	d.SetId(res3.StretchID)
 
 	return resourceL2ExtensionRead(ctx, d, m)
 

--- a/resource_location.go
+++ b/resource_location.go
@@ -90,7 +90,7 @@ func resourceLocationUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	city := d.Get("city").(string)
 	country := d.Get("country").(string)
-	cityAscii := city
+	CityASCII := city
 	latitude := d.Get("latitude").(float64)
 	longitude := d.Get("longitude").(float64)
 	province := d.Get("province").(string)
@@ -98,7 +98,7 @@ func resourceLocationUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	body := hcx.SetLocationBody{
 		City:      city,
 		Country:   country,
-		CityAscii: cityAscii,
+		CityASCII: CityASCII,
 		Latitude:  latitude,
 		Longitude: longitude,
 		Province:  province,
@@ -122,7 +122,7 @@ func resourceLocationDelete(ctx context.Context, d *schema.ResourceData, m inter
 	body := hcx.SetLocationBody{
 		City:      "",
 		Country:   "",
-		CityAscii: "",
+		CityASCII: "",
 		Latitude:  0,
 		Longitude: 0,
 		Province:  "",

--- a/resource_network_profile.go
+++ b/resource_network_profile.go
@@ -119,41 +119,41 @@ func resourceNetworkProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	mtu := d.Get("mtu").(int)
-	prefix_length := d.Get("prefix_length").(int)
+	prefixLength := d.Get("prefix_length").(int)
 
 	name := d.Get("name").(string)
 	gateway := d.Get("gateway").(string)
 
-	primary_dns := d.Get("primary_dns").(string)
-	secondary_dns := d.Get("secondary_dns").(string)
-	dns_suffix := d.Get("dns_suffix").(string)
+	primaryDNS := d.Get("primary_dns").(string)
+	secondaryDNS := d.Get("secondary_dns").(string)
+	dnsSuffix := d.Get("dns_suffix").(string)
 
 	sp := d.Get("site_pairing").(map[string]interface{})
-	vcuuid := sp["local_vc"].(string)
-	vclocalendpointid := sp["local_endpoint_id"].(string)
+	vcUUID := sp["local_vc"].(string)
+	vcLocalEndpointID := sp["local_endpoint_id"].(string)
 
-	network_name, ok := d.GetOk("network_name")
+	networkName, ok := d.GetOk("network_name")
 	if !ok && !vmc {
 		return diag.Errorf("VMC switch is not enabled. Network name is mandatory")
 	}
-	network_type := d.Get("network_type").(string)
-	network_id, err := hcx.GetNetworkBacking(client, vclocalendpointid, network_name.(string), network_type)
+	networkType := d.Get("network_type").(string)
+	networkiD, err := hcx.GetNetworkBacking(client, vcLocalEndpointID, networkName.(string), networkType)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Get IP Ranges from schema
-	ip_range := d.Get("ip_range").([]interface{})
+	ipRange := d.Get("ip_range").([]interface{})
 
-	ipr := []hcx.NetworkIpRange{}
-	for _, j := range ip_range {
+	ipr := []hcx.NetworkIPRange{}
+	for _, j := range ipRange {
 		s := j.(map[string]interface{})
-		start_address := s["start_address"].(string)
-		end_address := s["end_address"].(string)
+		startAddress := s["start_address"].(string)
+		endAddress := s["end_address"].(string)
 
-		ipr = append(ipr, hcx.NetworkIpRange{
-			StartAddress: start_address,
-			EndAddress:   end_address,
+		ipr = append(ipr, hcx.NetworkIPRange{
+			StartAddress: startAddress,
+			EndAddress:   endAddress,
 		})
 	}
 
@@ -162,20 +162,20 @@ func resourceNetworkProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		Organization: "DEFAULT",
 		MTU:          mtu,
 		Backings: []hcx.Backing{{
-			BackingID:           network_id.EntityID,
-			BackingName:         network_name.(string),
-			VCenterInstanceUuid: vcuuid,
-			Type:                network_type,
+			BackingID:           networkiD.EntityID,
+			BackingName:         networkName.(string),
+			VCenterInstanceUUID: vcUUID,
+			Type:                networkType,
 		},
 		},
 		IPScopes: []hcx.IPScope{
 			{
-				DnsSuffix:       dns_suffix,
+				DNSSuffix:       dnsSuffix,
 				Gateway:         gateway,
-				PrefixLength:    prefix_length,
-				PrimaryDns:      primary_dns,
-				SecondaryDns:    secondary_dns,
-				NetworkIpRanges: ipr,
+				PrefixLength:    prefixLength,
+				PrimaryDNS:      primaryDNS,
+				SecondaryDNS:    secondaryDNS,
+				NetworkIPRanges: ipr,
 			},
 		},
 		L3TenantManaged: false,
@@ -214,7 +214,7 @@ func resourceNetworkProfileRead(ctx context.Context, d *schema.ResourceData, m i
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(np.ObjectId)
+	d.SetId(np.ObjectID)
 
 	return diags
 }
@@ -226,37 +226,37 @@ func resourceNetworkProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 	// Get values from schema
 	vmc := d.Get("vmc").(bool)
 	mtu := d.Get("mtu").(int)
-	prefix_length := d.Get("prefix_length").(int)
+	prefixLength := d.Get("prefix_length").(int)
 
 	name := d.Get("name").(string)
 	gateway := d.Get("gateway").(string)
 
-	primary_dns := d.Get("primary_dns").(string)
-	secondary_dns := d.Get("secondary_dns").(string)
-	dns_suffix := d.Get("dns_suffix").(string)
-	network_name := d.Get("network_name").(string)
-	network_type := d.Get("network_type").(string)
+	primaryDNS := d.Get("primary_dns").(string)
+	secondaryDNS := d.Get("secondary_dns").(string)
+	dnsSuffix := d.Get("dns_suffix").(string)
+	networkName := d.Get("network_name").(string)
+	networkType := d.Get("network_type").(string)
 
 	sp := d.Get("site_pairing").(map[string]interface{})
-	vcuuid := sp["local_vc"].(string)
-	vclocalendpointid := sp["local_endpoint_id"].(string)
+	vcUUID := sp["local_vc"].(string)
+	vcLocalEndpointID := sp["local_endpoint_id"].(string)
 
 	// Get IP Ranges from schema
-	ip_range := d.Get("ip_range").([]interface{})
+	ipRange := d.Get("ip_range").([]interface{})
 
-	ipr := []hcx.NetworkIpRange{}
-	for _, j := range ip_range {
+	ipr := []hcx.NetworkIPRange{}
+	for _, j := range ipRange {
 		s := j.(map[string]interface{})
-		start_address := s["start_address"].(string)
-		end_address := s["end_address"].(string)
+		startAddress := s["start_address"].(string)
+		endAddress := s["end_address"].(string)
 
-		ipr = append(ipr, hcx.NetworkIpRange{
-			StartAddress: start_address,
-			EndAddress:   end_address,
+		ipr = append(ipr, hcx.NetworkIPRange{
+			StartAddress: startAddress,
+			EndAddress:   endAddress,
 		})
 	}
 
-	// Read the exisint profile
+	// Read the exising profile
 	body, err := hcx.GetNetworkProfile(client, name)
 	if err != nil {
 		return diag.FromErr(err)
@@ -268,16 +268,16 @@ func resourceNetworkProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 		body.Name = name
 
 		// Get network details
-		network_id, err := hcx.GetNetworkBacking(client, vclocalendpointid, network_name, network_type)
+		networkID, err := hcx.GetNetworkBacking(client, vcLocalEndpointID, networkName, networkType)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		body.Backings = []hcx.Backing{{
-			BackingID:           network_id.EntityID,
-			BackingName:         network_name,
-			VCenterInstanceUuid: vcuuid,
-			Type:                network_type,
+			BackingID:           networkID.EntityID,
+			BackingName:         networkName,
+			VCenterInstanceUUID: vcUUID,
+			Type:                networkType,
 		}}
 	}
 
@@ -285,12 +285,12 @@ func resourceNetworkProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	body.IPScopes = []hcx.IPScope{
 		{
-			DnsSuffix:       dns_suffix,
+			DNSSuffix:       dnsSuffix,
 			Gateway:         gateway,
-			PrefixLength:    prefix_length,
-			PrimaryDns:      primary_dns,
-			SecondaryDns:    secondary_dns,
-			NetworkIpRanges: ipr,
+			PrefixLength:    prefixLength,
+			PrimaryDNS:      primaryDNS,
+			SecondaryDNS:    secondaryDNS,
+			NetworkIPRanges: ipr,
 			PoolID:          body.IPScopes[0].PoolID,
 		},
 	}
@@ -336,7 +336,7 @@ func resourceNetworkProfileDelete(ctx context.Context, d *schema.ResourceData, m
 			}
 
 			// Empty the IP Ranges
-			body.IPScopes[0].NetworkIpRanges = []hcx.NetworkIpRange{}
+			body.IPScopes[0].NetworkIPRanges = []hcx.NetworkIPRange{}
 
 			res, err = hcx.UpdateNetworkProfile(client, body)
 

--- a/resource_rolemapping.go
+++ b/resource_rolemapping.go
@@ -77,26 +77,26 @@ func resourceRoleMappingUpdate(ctx context.Context, d *schema.ResourceData, m in
 	admin := d.Get("admin").([]interface{})
 	enterprise := d.Get("enterprise").([]interface{})
 
-	admin_groups := []string{}
+	adminGroups := []string{}
 	for _, j := range admin {
 		tmp := j.(map[string]interface{})
-		admin_groups = append(admin_groups, tmp["user_group"].(string))
+		adminGroups = append(adminGroups, tmp["user_group"].(string))
 	}
 
-	enterprise_groups := []string{}
+	enterpriseGroups := []string{}
 	for _, j := range enterprise {
 		tmp := j.(map[string]interface{})
-		enterprise_groups = append(enterprise_groups, tmp["user_group"].(string))
+		enterpriseGroups = append(enterpriseGroups, tmp["user_group"].(string))
 	}
 
 	body := []hcx.RoleMapping{
 		{
 			Role:       "System Administrator",
-			UserGroups: admin_groups,
+			UserGroups: adminGroups,
 		},
 		{
 			Role:       "Enterprise Administrator",
-			UserGroups: enterprise_groups,
+			UserGroups: enterpriseGroups,
 		},
 	}
 	/*

--- a/resource_site_pairing.go
+++ b/resource_site_pairing.go
@@ -91,7 +91,7 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 	password := d.Get("password").(string)
 
 	body := hcx.RemoteCloudConfigBody{
-		Remote: hcx.Remote_data{
+		Remote: hcx.RemoteData{
 			Username: username,
 			Password: password,
 			URL:      url,
@@ -104,7 +104,7 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	second_try := false
+	secondTry := false
 	if res.Errors != nil {
 		if res.Errors[0].Error == "Login failure" {
 			return diag.Errorf("%s", res.Errors[0].Text)
@@ -112,8 +112,8 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		if len(res.Errors[0].Data) > 0 {
 			// Try to get certificate
-			certificate_raw := res.Errors[0].Data[0]
-			certificate, ok := certificate_raw["certificate"].(string)
+			certificateRaw := res.Errors[0].Data[0]
+			certificate, ok := certificateRaw["certificate"].(string)
 
 			if ok {
 				// Add certificate
@@ -129,10 +129,10 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 			return diag.Errorf("Unknown error(s): %+v", res.Errors)
 		}
 
-		second_try = true
+		secondTry = true
 	}
 
-	if second_try {
+	if secondTry {
 		res, err = hcx.InsertSitePairing(client, body)
 		if err != nil {
 			return diag.FromErr(err)
@@ -206,20 +206,20 @@ func resourceSitePairingRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	for _, item := range res.Data.Items {
 		if item.URL == url {
-			d.SetId(item.EndpointId)
+			d.SetId(item.EndpointID)
 
 			lc, err := hcx.GetLocalContainer(client)
 			if err != nil {
 				return diag.FromErr(errors.New("cannot get local container info"))
 			}
 
-			d.Set("local_vc", lc.Vcuuid)
+			d.Set("local_vc", lc.VcUUID)
 
 			rc, err := hcx.GetRemoteContainer(client)
 			if err != nil {
 				return diag.FromErr(errors.New("cannot get remote container info"))
 			}
-			d.Set("remote_resource_id", rc.ResourceId)
+			d.Set("remote_resource_id", rc.ResourceID)
 			d.Set("remote_resource_type", rc.ResourceType)
 			d.Set("remote_resource_name", rc.ResourceName)
 
@@ -240,7 +240,7 @@ func resourceSitePairingRead(ctx context.Context, d *schema.ResourceData, m inte
 			if err != nil {
 				return diag.FromErr(errors.New("cannot get remote cloud info"))
 			}
-			d.Set("local_endpoint_id", res3.Data.Items[0].EndpointId)
+			d.Set("local_endpoint_id", res3.Data.Items[0].EndpointID)
 			d.Set("local_name", res3.Data.Items[0].Name)
 
 			return diags

--- a/resource_sso.go
+++ b/resource_sso.go
@@ -45,7 +45,7 @@ func resourceSSOCreate(ctx context.Context, d *schema.ResourceData, m interface{
 			Items: []hcx.InsertSSODataItem{
 				{
 					Config: hcx.InsertSSODataItemConfig{
-						LookupServiceUrl: url,
+						LookupServiceURL: url,
 						ProviderType:     "PSC",
 					},
 				},
@@ -94,7 +94,7 @@ func resourceSSOUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 			Items: []hcx.InsertSSODataItem{
 				{
 					Config: hcx.InsertSSODataItemConfig{
-						LookupServiceUrl: url,
+						LookupServiceURL: url,
 						UUID:             d.Id(),
 						ProviderType:     "PSC",
 					},

--- a/resource_vmc.go
+++ b/resource_vmc.go
@@ -57,20 +57,20 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*hcx.Client)
 
 	token := client.Token
-	sddc_name := d.Get("sddc_name").(string)
+	sddcName := d.Get("sddc_name").(string)
 	sddcID := d.Get("sddc_id").(string)
 
-	if sddc_name == "" && sddcID == "" {
+	if sddcName == "" && sddcID == "" {
 		return diag.Errorf("SDDC name or Id must be specified")
 	}
 
 	// Authenticate with VMware Cloud Services
-	access_token, err := hcx.VmcAuthenticate(token)
+	accessToken, err := hcx.VmcAuthenticate(token)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = hcx.CloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, accessToken)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -79,7 +79,7 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	if sddcID != "" {
 		sddc, err = hcx.GetSddcByID(client, sddcID)
 	} else {
-		sddc, err = hcx.GetSddcByName(client, sddc_name)
+		sddc, err = hcx.GetSddcByName(client, sddcName)
 	}
 
 	if err != nil {
@@ -103,7 +103,7 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		if sddcID != "" {
 			sddc, err = hcx.GetSddcByID(client, sddcID)
 		} else {
-			sddc, err = hcx.GetSddcByName(client, sddc_name)
+			sddc, err = hcx.GetSddcByName(client, sddcName)
 		}
 		if err != nil {
 			// Attempt to bypass recurring situation where the HCX API
@@ -136,24 +136,24 @@ func resourceVmcRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	client := m.(*hcx.Client)
 
 	token := client.Token
-	sddc_name := d.Get("sddc_name").(string)
+	sddcName := d.Get("sddc_name").(string)
 	sddcID := d.Get("sddc_id").(string)
 
 	log.Printf("******************************************************************\n")
-	log.Printf("token: %s, sddc_name: %s,   sddc: %s   \n", token, sddc_name, sddcID)
+	log.Printf("token: %s, sddc_name: %s,   sddc: %s   \n", token, sddcName, sddcID)
 	log.Printf("******************************************************************\n")
 
-	if sddc_name == "" && sddcID == "" {
+	if sddcName == "" && sddcID == "" {
 		return diag.Errorf("SDDC name or Id must be specified")
 	}
 
 	// Authenticate with VMware Cloud Services
-	access_token, err := hcx.VmcAuthenticate(token)
+	accessToken, err := hcx.VmcAuthenticate(token)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = hcx.CloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, accessToken)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -166,7 +166,7 @@ func resourceVmcRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	if sddcID != "" {
 		sddc, err = hcx.GetSddcByID(client, sddcID)
 	} else {
-		sddc, err = hcx.GetSddcByName(client, sddc_name)
+		sddc, err = hcx.GetSddcByName(client, sddcName)
 	}
 	if err != nil {
 		return diag.FromErr(err)
@@ -191,16 +191,16 @@ func resourceVmcDelete(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*hcx.Client)
 
 	token := client.Token
-	sddc_name := d.Get("sddc_name").(string)
+	sddcName := d.Get("sddc_name").(string)
 	sddcID := d.Get("sddc_id").(string)
 
 	// Authenticate with VMware Cloud Services
-	access_token, err := hcx.VmcAuthenticate(token)
+	accessToken, err := hcx.VmcAuthenticate(token)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = hcx.CloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, accessToken)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -209,7 +209,7 @@ func resourceVmcDelete(ctx context.Context, d *schema.ResourceData, m interface{
 	if sddcID != "" {
 		sddc, err = hcx.GetSddcByID(client, sddcID)
 	} else {
-		sddc, err = hcx.GetSddcByName(client, sddc_name)
+		sddc, err = hcx.GetSddcByName(client, sddcName)
 	}
 	if err != nil {
 		return diag.FromErr(err)
@@ -228,7 +228,7 @@ func resourceVmcDelete(ctx context.Context, d *schema.ResourceData, m interface{
 		if sddcID != "" {
 			sddc, err = hcx.GetSddcByID(client, sddcID)
 		} else {
-			sddc, err = hcx.GetSddcByName(client, sddc_name)
+			sddc, err = hcx.GetSddcByName(client, sddcName)
 		}
 		if err != nil {
 			// Attempt to bypass recurring situation where the HCX API


### PR DESCRIPTION

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This pull request includes a series of changes focused on standardizing the naming conventions across the codebase, primarily converting camelCase identifiers to PascalCase. The changes span multiple files and functions, ensuring consistency and readability.

### Standardization of Naming Conventions:

* [`data_source_compute_profile.go`](diffhunk://#diff-15a8e50b4a9668c3e6453356567f5ded5a43b2d6a805ea3e4363f919d162f439L44-R50): Renamed `EndpointId` to `EndpointID` and `ComputeProfileId` to `ComputeProfileID` in `func dataSourceComputeProfileRead`.
* [`data_source_network_backing.go`](diffhunk://#diff-89cbd5aad38e230de95b3991ad4d157b1e2e4524e84021c347a0900c72e16aeaL47-R50): Updated `vcuuid` to `vcUUID` and `network_type` to `networkType` in `func dataSourceNetworkBackingRead`.
* [`hcx/client.go`](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L119-R129): Changed `certificate_pb` to `certificatePb`, and updated parameters in `NewClient` function to PascalCase. [[1]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L119-R129) [[2]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L145-R156)
* [`hcx/compute_profile.go`](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL27-R46): Standardized various identifiers such as `CmpId` to `ComputeID`, `InterconnectTaskId` to `InterconnectTaskID`, and `ComputeProfileId` to `ComputeProfileID`. [[1]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL27-R46) [[2]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL68-R68) [[3]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL80-R89) [[4]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL159-R163) [[5]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL184-R184)
* [`hcx/l2_extension.go`](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L16-R19): Renamed identifiers like `VcGuid` to `VcGUID`, `Dns` to `DNS`, and corrected spelling errors in type names. [[1]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L16-R19) [[2]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L28-R35) [[3]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L46-R55) [[4]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L64-R64) [[5]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L78-R80) [[6]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L109-R109) [[7]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L134-R134)
* [`hcx/location.go`](diffhunk://#diff-72c4a571cc2d986147d77adb7f5a56a5abf2b6f18f96dd449f6ee4dbb171a8e3L17-R17): Updated `CityAscii` to `CityASCII` in `SetLocationBody` and `GetLocationResult`. [[1]](diffhunk://#diff-72c4a571cc2d986147d77adb7f5a56a5abf2b6f18f96dd449f6ee4dbb171a8e3L17-R17) [[2]](diffhunk://#diff-72c4a571cc2d986147d77adb7f5a56a5abf2b6f18f96dd449f6ee4dbb171a8e3L27-R27)
* [`hcx/network_profile.go`](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L24-R24): Changed `ObjectId` to `ObjectID`, `VCenterInstanceUuid` to `VCenterInstanceUUID`, and other related identifiers. [[1]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L24-R24) [[2]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L40-R54) [[3]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L68-R68) [[4]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L145-R146) [[5]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L180-R180) [[6]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L224-R224)
* [`hcx/role_mapping.go`](diffhunk://#diff-2c7f9019b79667392dfffd1ba9316acd26e2545f50b01514dc66dbd876004a07L22-R22): Renamed `HttpStatusCode` to `HTTPStatusCode` in `RoleMappingResult`.
* [`hcx/service_mesh.go`](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L15-R17): Updated `ComputeProfileId` to `ComputeProfileID`, `EndpointId` to `EndpointID`, and other related identifiers. [[1]](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L15-R17) [[2]](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L27-R27) [[3]](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L49-R59)
* [`hcx/site_pairing.go`](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L14-R23): Changed `Remote_data` to `RemoteData`, `EndpointId` to `EndpointID`, and other related identifiers. [[1]](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L14-R23) [[2]](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L54-R54) [[3]](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L123-R127)

These changes enhance code consistency and readability, making it easier to maintain and understand the codebase.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Ref: #42

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [ ] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
