### PR TITLE
chore: errcount shorthand

### DIFF
--- a/resource_vmc.go
+++ b/resource_vmc.go
@@ -105,7 +105,7 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 			// Attempt to bypass recurring situation where the HCX API
 			// returns status 502 with a proxy server error, and an HTML response
 			// instead of JSON.
-			errcount += 1
+			errcount++
 			hclog.Default().Info("[INFO] - resourceVmcCreate() - Error retrieving SDDC status: ", "error", err.Error(), "Errcount:", errcount)
 			if errcount > 12 {
 				return diag.FromErr(err)
@@ -230,7 +230,7 @@ func resourceVmcDelete(ctx context.Context, d *schema.ResourceData, m interface{
 			// Attempt to bypass recurring situation where the HCX API
 			// returns status 502 with a proxy server error, and an HTML response
 			// instead of JSON.
-			errcount += 1
+			errcount++
 			hclog.Default().Info("[INFO] - resourceVmcDelete() - Error retrieving SDDC status: ", "error", err.Error(), "Errcount:", errcount)
 			if errcount > 12 {
 				return diag.FromErr(err)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Use Shorthand Increment Operator: Replace `errcount += 1` with `errcount++`, as it is a more concise and conventional way to increment an integer by 1 in Go. This minor refactoring improves code readability and aligns with common Go practices.

* [`resource_vmc.go`](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL108-R108): Changed `errcount += 1` to `errcount++` in the `resourceVmcCreate` function to simplify the code.
* [`resource_vmc.go`](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL233-R233): Changed `errcount += 1` to `errcount++` in the `resourceVmcDelete` function to simplify the code.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Ref: #42

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
