### PR TITLE
chore: remove stutters

### DIFF
--- a/hcx/vmc.go
+++ b/hcx/vmc.go
@@ -40,7 +40,7 @@ type VmcAccessToken struct {
 	RefreshToken string `json:"refreshToken"`
 }
 
-type HcxCloudAuthorizationBody struct {
+type CloudAuthorizationBody struct {
 	Token string `json:"token"`
 }
 
@@ -87,14 +87,14 @@ func VmcAuthenticate(token string) (string, error) {
 
 }
 
-func HcxCloudAuthenticate(client *Client, token string) error {
+func CloudAuthenticate(client *Client, token string) error {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
 		HostURL:    "https://connect.hcx.vmware.com/provider/csp",
 	}
 
-	body := HcxCloudAuthorizationBody{
+	body := CloudAuthorizationBody{
 		Token: token,
 	}
 

--- a/resource_vmc.go
+++ b/resource_vmc.go
@@ -66,7 +66,7 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diag.FromErr(err)
 	}
 
-	err = hcx.HcxCloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, access_token)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -149,7 +149,7 @@ func resourceVmcRead(ctx context.Context, d *schema.ResourceData, m interface{})
 		return diag.FromErr(err)
 	}
 
-	err = hcx.HcxCloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, access_token)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -196,7 +196,7 @@ func resourceVmcDelete(ctx context.Context, d *schema.ResourceData, m interface{
 		return diag.FromErr(err)
 	}
 
-	err = hcx.HcxCloudAuthenticate(client, access_token)
+	err = hcx.CloudAuthenticate(client, access_token)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Renames several types and functions to improve consistency and clarity in the codebase. The most important changes include renaming the `HcxCloudAuthorizationBody` struct and the `HcxCloudAuthenticate` function, and updating their references in the `resource_vmc.go` file.

```shell
~/Code/terraform-provider-hcx git:[chore/errcount-shorthand]
make lint | grep stutter
hcx/vmc.go:43:6: exported: type name will be used as hcx.HcxCloudAuthorizationBody by other packages, and that stutters; consider calling this CloudAuthorizationBody (revive)
hcx/vmc.go:90:6: exported: func name will be used as hcx.HcxCloudAuthenticate by other packages, and that stutters; consider calling this CloudAuthenticate (revive)
make: *** [lint] Error 1
```

Renaming:

* [`hcx/vmc.go`](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL43-R43): Renamed `HcxCloudAuthorizationBody` to `CloudAuthorizationBody` and updated its usage in the `CloudAuthenticate` function. [[1]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL43-R43) [[2]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL90-R97)
* [`hcx/vmc.go`](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL90-R97): Renamed `HcxCloudAuthenticate` to `CloudAuthenticate` and updated its implementation to use the new `CloudAuthorizationBody` struct.

Updated References:

* [`resource_vmc.go`](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL69-R69): Updated references to the renamed `CloudAuthenticate` function in the `resourceVmcCreate`, `resourceVmcRead`, and `resourceVmcDelete` functions. [[1]](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL69-R69) [[2]](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL152-R152) [[3]](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL199-R199)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Ref: #42

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
