### PR TITLE
chore: bytes.Buffer

### DIFF
--- a/hcx/activation.go
+++ b/hcx/activation.go
@@ -34,10 +34,10 @@ func PostActivate(c *Client, body ActivateBody) (ActivateBody, error) {
 
 	resp := ActivateBody{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err
@@ -93,10 +93,10 @@ func DeleteActivate(c *Client, body ActivateBody) (ActivateBody, error) {
 
 	resp := ActivateBody{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), buf)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/certificate.go
+++ b/hcx/certificate.go
@@ -25,10 +25,10 @@ func InsertCertificate(c *Client, body InsertCertificateBody) (InsertCertificate
 
 	resp := InsertCertificateResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/admin/certificates", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/admin/certificates", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/compute_profile.go
+++ b/hcx/compute_profile.go
@@ -101,10 +101,10 @@ func InsertComputeProfile(c *Client, body InsertComputeProfileBody) (InsertCompu
 
 	resp := InsertComputeProfileResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/l2_extension.go
+++ b/hcx/l2_extension.go
@@ -79,10 +79,10 @@ func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2Extention
 
 	resp := InsertL2ExtentionResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/l2Extensions", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/l2Extensions", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/location.go
+++ b/hcx/location.go
@@ -32,10 +32,10 @@ type GetLocationResult struct {
 // SetLocation ...
 func SetLocation(c *Client, body SetLocationBody) error {
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/location", c.HostURL), buf)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/location", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return err

--- a/hcx/network_profile.go
+++ b/hcx/network_profile.go
@@ -73,10 +73,10 @@ func InsertNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 
 	resp := NetworkProfileResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/admin/hybridity/api/networks", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/admin/hybridity/api/networks", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err
@@ -110,10 +110,10 @@ func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return NetworkProfileBody{}, err
@@ -153,10 +153,10 @@ func GetNetworkProfileById(c *Client, id string) (NetworkProfileBody, error) {
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return NetworkProfileBody{}, err
@@ -218,10 +218,10 @@ func UpdateNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 
 	resp := NetworkProfileResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectId), buf)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectId), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/role_mapping.go
+++ b/hcx/role_mapping.go
@@ -27,10 +27,10 @@ func PutRoleMapping(c *Client, body []RoleMapping) (RoleMappingResult, error) {
 
 	resp := RoleMappingResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/roleMappings", c.HostURL), buf)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/roleMappings", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/service_mesh.go
+++ b/hcx/service_mesh.go
@@ -64,10 +64,10 @@ func InsertServiceMesh(c *Client, body InsertServiceMeshBody) (InsertServiceMesh
 
 	resp := InsertServiceMeshResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/serviceMesh", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/serviceMesh", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/site_pairing.go
+++ b/hcx/site_pairing.go
@@ -65,10 +65,10 @@ func InsertSitePairing(c *Client, body RemoteCloudConfigBody) (PostRemoteCloudCo
 
 	resp := PostRemoteCloudConfigResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/cloudConfigs", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/cloudConfigs", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/sso.go
+++ b/hcx/sso.go
@@ -74,10 +74,10 @@ func InsertSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 
 	resp := InsertSSOResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err
@@ -105,10 +105,10 @@ func UpdateSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 
 	resp := InsertSSOResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice/%s", c.HostURL, body.Data.Items[0].Config.UUID), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice/%s", c.HostURL, body.Data.Items[0].Config.UUID), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/utils.go
+++ b/hcx/utils.go
@@ -301,12 +301,12 @@ func GetLocalContainer(c *Client) (PostResouceContainerListResultDataItem, error
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := PostResouceContainerListResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return PostResouceContainerListResultDataItem{}, err
@@ -341,12 +341,12 @@ func GetRemoteContainer(c *Client) (PostResouceContainerListResultDataItem, erro
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := PostResouceContainerListResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return PostResouceContainerListResultDataItem{}, err
@@ -380,12 +380,12 @@ func GetNetworkBacking(c *Client, endpointid string, network string, network_typ
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := PostNetworkBackingResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/networks", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/networks", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return Dvpg{}, err
@@ -460,12 +460,12 @@ func GetVcDatastore(c *Client, datastore_name string, vcuuid string, cluster str
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := GetVcDatastoreResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/datastores/query", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/datastores/query", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return GetVcDatastoreResultDataItem{}, err
@@ -505,12 +505,12 @@ func GetVcDvs(c *Client, dvs_name string, vcuuid string, cluster string) (GetVcD
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := GetVcDvsResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/dvs/query", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/dvs/query", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return GetVcDvsResultDataItem{}, err
@@ -548,12 +548,12 @@ func GetRemoteCloudList(c *Client) (PostCloudListResult, error) {
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := PostCloudListResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return PostCloudListResult{}, err
@@ -585,12 +585,12 @@ func GetLocalCloudList(c *Client) (PostCloudListResult, error) {
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := PostCloudListResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return PostCloudListResult{}, err
@@ -623,12 +623,12 @@ func GetAppliance(c *Client, endpointId string, service_mesh_id string) (GetAppl
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := GetApplianceResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return GetApplianceResultItem{}, err
@@ -668,12 +668,12 @@ func GetAppliances(c *Client, endpointId string, service_mesh_id string) ([]GetA
 		},
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
 	resp := GetApplianceResult{}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return []GetApplianceResultItem{}, err

--- a/hcx/vcenter.go
+++ b/hcx/vcenter.go
@@ -44,10 +44,10 @@ func InsertvCenter(c *Client, body InsertvCenterBody) (InsertvCenterResult, erro
 
 	resp := InsertvCenterResult{}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/vcenter", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/vcenter", c.HostURL), &buf)
 	if err != nil {
 		fmt.Println(err)
 		return resp, err

--- a/hcx/vmc.go
+++ b/hcx/vmc.go
@@ -98,10 +98,10 @@ func CloudAuthenticate(client *Client, token string) error {
 		Token: token,
 	}
 
-	buf := new(bytes.Buffer)
-	json.NewEncoder(buf).Encode(body)
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sessions", c.HostURL), buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/sessions", c.HostURL), &buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Use `var buf bytes.Buffer` which creates a `bytes.Buffer` value directly. This approach as it avoids an unnecessary pointer and is more idiomatic in Go.

Improvements to HTTP request body handling:

* [`hcx/activation.go`](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L37-R40): Updated `PostActivate` and `DeleteActivate` functions to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests. [[1]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L37-R40) [[2]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L96-R99)
* [`hcx/certificate.go`](diffhunk://#diff-73333f714840ba3f587cab1dd634dca4e693d942368b6eb797c530b7d93b5546L28-R31): Modified `InsertCertificate` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/compute_profile.go`](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL104-R107): Updated `InsertComputeProfile` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/l2_extension.go`](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L82-R85): Modified `InsertL2Extension` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/location.go`](diffhunk://#diff-72c4a571cc2d986147d77adb7f5a56a5abf2b6f18f96dd449f6ee4dbb171a8e3L35-R38): Updated `SetLocation` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/network_profile.go`](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L76-R79): Updated multiple functions (`InsertNetworkProfile`, `GetNetworkProfile`, `GetNetworkProfileById`, `UpdateNetworkProfile`) to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests. [[1]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L76-R79) [[2]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L113-R116) [[3]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L156-R159) [[4]](diffhunk://#diff-d8c55362026857fd708f04b6e0422ef768e9900c1f3fe9505e3b833b60081932L221-R224)
* [`hcx/role_mapping.go`](diffhunk://#diff-2c7f9019b79667392dfffd1ba9316acd26e2545f50b01514dc66dbd876004a07L30-R33): Modified `PutRoleMapping` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/service_mesh.go`](diffhunk://#diff-203f8eb145d48afe7ae03ccb7f0e321df1f4a75add2edec499bbf4999ed5d0d6L67-R70): Updated `InsertServiceMesh` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/site_pairing.go`](diffhunk://#diff-8212c60458c3c95d15f17ec4c7a1d6c50225cce318716260aa5a36b7af75fee5L68-R71): Modified `InsertSitePairing` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/sso.go`](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL77-R80): Updated `InsertSSO` and `UpdateSSO` functions to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests. [[1]](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL77-R80) [[2]](diffhunk://#diff-239e2024e777420f0c76c4d7d756349f58304eca5b3be1cb9497d2b5dd0f73aaL108-R111)
* [`hcx/utils.go`](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL304-R309): Updated multiple functions (`GetLocalContainer`, `GetRemoteContainer`, `GetNetworkBacking`, `GetVcDatastore`, `GetVcDvs`, `GetRemoteCloudList`, `GetLocalCloudList`, `GetAppliance`, `GetAppliances`) to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests. [[1]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL304-R309) [[2]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL344-R349) [[3]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL383-R388) [[4]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL463-R468) [[5]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL508-R513) [[6]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL551-R556) [[7]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL588-R593) [[8]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL626-R631) [[9]](diffhunk://#diff-545bcbcbe421501f55f347c53df5a1170180ebdc30caaf19a733e36ed5e10f4dL671-R676)
* [`hcx/vcenter.go`](diffhunk://#diff-64f1cee2f6ec02f868ddcea76fa5f425afe1c375219396b50363f2905a4090ffL47-R50): Modified `InsertvCenter` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.
* [`hcx/vmc.go`](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL101-R104): Updated `HcxCloudAuthenticate` function to use `var buf bytes.Buffer` and pass the buffer by reference in HTTP requests.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
