### PR TITLE
fix: staticcheck ST1005

### DIFF
--- a/resource_compute_profile.go
+++ b/resource_compute_profile.go
@@ -311,7 +311,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		if jr.Status == "FAILED" {
-			return diag.FromErr(errors.New("Task Failed"))
+			return diag.FromErr(errors.New("task failed"))
 		}
 
 		time.Sleep(5 * time.Second)
@@ -356,7 +356,7 @@ func resourceComputeProfileDelete(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		if jr.Status == "FAILED" {
-			return diag.FromErr(errors.New("Task Failed"))
+			return diag.FromErr(errors.New("task failed"))
 		}
 
 		time.Sleep(5 * time.Second)

--- a/resource_service_mesh.go
+++ b/resource_service_mesh.go
@@ -193,7 +193,7 @@ func resourceServiceMeshCreate(ctx context.Context, d *schema.ResourceData, m in
 		}
 
 		if jr.Status == "FAILED" {
-			return diag.FromErr(errors.New("Task Failed"))
+			return diag.FromErr(errors.New("task failed"))
 		}
 
 		time.Sleep(5 * time.Second)
@@ -254,7 +254,7 @@ func resourceServiceMeshDelete(ctx context.Context, d *schema.ResourceData, m in
 		}
 
 		if jr.Status == "FAILED" {
-			return diag.FromErr(errors.New("Task Failed"))
+			return diag.FromErr(errors.New("task failed"))
 		}
 
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Resolves ST1005 from `staticcheck` results.

Includes changes to standardize error messages across multiple functions by updating the error text to use consistent capitalization.

Standardization of error messages:

* [`resource_compute_profile.go`](diffhunk://#diff-6249d4a6ecea06e7c758a5ffe69b9f7ef651c9c15b830a99ec6e5ee4fc1c8b86L314-R314): Updated the error message in `resourceComputeProfileCreate` and `resourceComputeProfileDelete` functions to use lowercase ("task failed") for consistency. [[1]](diffhunk://#diff-6249d4a6ecea06e7c758a5ffe69b9f7ef651c9c15b830a99ec6e5ee4fc1c8b86L314-R314) [[2]](diffhunk://#diff-6249d4a6ecea06e7c758a5ffe69b9f7ef651c9c15b830a99ec6e5ee4fc1c8b86L359-R359)
* [`resource_service_mesh.go`](diffhunk://#diff-9e8db08b46b8f699b82b627de91f9a1c1723e3014efe16134a953b8d92b9b921L196-R196): Updated the error message in `resourceServiceMeshCreate` function to use lowercase ("task failed") for consistency.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [x] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
