### PR TITLE
chore: remove redundant alias

### DIFF
--- a/data_source_compute_profile.go
+++ b/data_source_compute_profile.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func dataSourceComputeProfile() *schema.Resource {

--- a/data_source_network_backing.go
+++ b/data_source_network_backing.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func dataSourceNetworkBacking() *schema.Resource {

--- a/resource_compute_profile.go
+++ b/resource_compute_profile.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourceComputeProfile() *schema.Resource {

--- a/resource_l2_extension.go
+++ b/resource_l2_extension.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourceL2Extension() *schema.Resource {

--- a/resource_network_profile.go
+++ b/resource_network_profile.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func NetSchema() map[string]*schema.Schema {

--- a/resource_service_mesh.go
+++ b/resource_service_mesh.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourceServiceMesh() *schema.Resource {

--- a/resource_site_pairing.go
+++ b/resource_site_pairing.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourceSitePairing() *schema.Resource {

--- a/resource_vcenter.go
+++ b/resource_vcenter.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourcevCenter() *schema.Resource {

--- a/resource_vmc.go
+++ b/resource_vmc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	hcx "github.com/vmware/terraform-provider-hcx/hcx"
+	"github.com/vmware/terraform-provider-hcx/hcx"
 )
 
 func resourceVmc() *schema.Resource {


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Removes redundant aliasing in import statements and reordering of imports.

* [`data_source_compute_profile.go`](diffhunk://#diff-15a8e50b4a9668c3e6453356567f5ded5a43b2d6a805ea3e4363f919d162f439L12-R12): Removed redundant aliasing from the `hcx` import.
* [`data_source_network_backing.go`](diffhunk://#diff-89cbd5aad38e230de95b3991ad4d157b1e2e4524e84021c347a0900c72e16aeaL12-R12): Removed redundant aliasing from the `hcx` import.
* [`resource_compute_profile.go`](diffhunk://#diff-6249d4a6ecea06e7c758a5ffe69b9f7ef651c9c15b830a99ec6e5ee4fc1c8b86L16-R16): Removed redundant aliasing from the `hcx` import.
* [`resource_l2_extension.go`](diffhunk://#diff-a5254d75951fdec1b33c61427a07b35ce4ad3427c4d857cc39fa0aace8d94c93L15-R15): Removed redundant aliasing from the `hcx` import.
* [`resource_network_profile.go`](diffhunk://#diff-c7cdf62a44de1f5d503beae38516f4541dc7be5e6818e14cd3c44b792cf4d064L13-R13): Removed redundant aliasing from the `hcx` import.
* [`resource_service_mesh.go`](diffhunk://#diff-9e8db08b46b8f699b82b627de91f9a1c1723e3014efe16134a953b8d92b9b921L16-R16): Removed redundant aliasing from the `hcx` import.
* [`resource_site_pairing.go`](diffhunk://#diff-ed7115103315d06de2c97bee7373df339152849799481e6b58f32a69d2beeae3L14-R14): Removed redundant aliasing from the `hcx` import.
* [`resource_vcenter.go`](diffhunk://#diff-3df6aee17487c06856ec4b209e048adab2a169e71de2a5d1066d65fa4e471979L15-R15): Removed redundant aliasing from the `hcx` import.
* [`resource_vmc.go`](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aR9-R15): Reordered imports by moving the `log` package import to the top and removing redundant aliasing from the `hcx` import.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
