### PR TITLE
fix: ensure at least one of

### DIFF
--- a/docs/resources/vmc.md
+++ b/docs/resources/vmc.md
@@ -24,10 +24,10 @@ resource "hcx_site_pairing" "example" {
 
 ## Argument Reference
 
-* `sddc_name` - (Optional) The name of the SDDC. Either `sddc_name` or `sddc_id`
-  must be specified.
-* `sddc_id` - (Optional) The ID of the SDDC. Either `sddc_id` or `sddc_name`
-  must be specified.
+* `sddc_name` - (Required) The name of the SDDC.
+* `sddc_id` - (Required) The ID of the SDDC.
+
+~> **NOTE:** Either `sddc_name` or `sddc_id` **must** be provided, but not both.
 
 ## Attribute Reference
 

--- a/resource_vmc.go
+++ b/resource_vmc.go
@@ -25,14 +25,16 @@ func resourceVmc() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"sddc_id": {
-				Type:        schema.TypeString,
-				Description: "The ID of the SDDC.",
-				Optional:    true,
+				Type:         schema.TypeString,
+				Description:  "The ID of the SDDC.",
+				Optional:     true,
+				ExactlyOneOf: []string{"sddc_id", "sddc_name"}, // Enforces that at least one of them is provided.
 			},
 			"sddc_name": {
-				Type:        schema.TypeString,
-				Description: "The name of the SDDC.",
-				Optional:    true,
+				Type:         schema.TypeString,
+				Description:  "The name of the SDDC.",
+				Optional:     true,
+				ExactlyOneOf: []string{"sddc_id", "sddc_name"}, // Enforces that at least one of them is provided.
 			},
 			"cloud_url": {
 				Type:        schema.TypeString,
@@ -61,10 +63,6 @@ func resourceVmcCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	token := client.Token
 	sddcName := d.Get("sddc_name").(string)
 	sddcID := d.Get("sddc_id").(string)
-
-	if sddcName == "" && sddcID == "" {
-		return diag.Errorf("SDDC name or Id must be specified")
-	}
 
 	// Authenticate with VMware Cloud Services
 	accessToken, err := hcx.VmcAuthenticate(token)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Includes changes to the `resource_vmc.go` and `vmc.md` files to enforce that either `sddc_name` or `sddc_id` must be provided, but not both. These changes ensure proper validation and documentation for the VMware Cloud Services resource.

Validation improvements:

* [`resource_vmc.go`](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aR31-R37): Added `ExactlyOneOf` validation to enforce that either `sddc_id` or `sddc_name` must be provided. [[1]](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aR31-R37) [[2]](diffhunk://#diff-7a42a0e3976504c97974e6a3af1cd0a42861f172a722c38472578851f447b23aL65-L68)

Documentation updates:

* [`vmc.md`](diffhunk://#diff-f98df29e078040ded2ffd51d9850ee1c4023106705a2b19bdfb9bf761e7066d2L27-R30): Updated the argument reference to reflect that `sddc_name` and `sddc_id` are required, and added a note specifying that only one of them must be provided.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

```shell
terraform validate
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vmware/hcx in /Users/johnsonryan/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
╷
│ Error: Invalid combination of arguments
│ 
│   with hcx_vmc.example,
│   on hcx.tf line 19, in resource "hcx_vmc" "example":
│   19:   sddc_name   = "example"
│ 
│ "sddc_name": only one of `sddc_id,sddc_name` can be specified, but `sddc_id,sddc_name` were specified.
╵
╷
│ Error: Invalid combination of arguments
│ 
│   with hcx_vmc.example,
│   on hcx.tf line 20, in resource "hcx_vmc" "example":
│   20:   sddc_id   = "example"
│ 
│ "sddc_id": only one of `sddc_id,sddc_name` can be specified, but `sddc_id,sddc_name` were specified.
╵
```

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
