### PR TITLE
refactor: constants and validators

### DIFF
--- a/docs/resources/l2_extension.md
+++ b/docs/resources/l2_extension.md
@@ -35,8 +35,8 @@ output "l2_extension_1" {
 
 ## Argument Reference
 
-* `site_pairing` - (Required) The site pairing used by this service mesh.
-* `service_mesh_id` - (Required) The ID of the Service Mesh to be used for this
+* `site_pairing` - (Required) The site pairing used for the L2 extension..
+* `service_mesh_id` - (Required) The ID of the Service Mesh to be used for the
   L2 extension.
 * `source_network` - (Required) The source network. Must be a distributed port
   group which is VLAN tagged.

--- a/docs/resources/network_profile.md
+++ b/docs/resources/network_profile.md
@@ -54,9 +54,9 @@ resource "hcx_network_profile" "net_management" {
 
 ## Argument Reference
 
-* `site_pairing` - (Required) The site pairing map, to be retrieved with the
-  `hcx_site_pairing` resource.
-* `network_name` - (Required) The network name used for the profile.
+* `site_pairing` - (Required) The site pairing map for the network profile,
+   to be retrieved with the`hcx_site_pairing` resource.
+* `network_name` - (Required) The network name for the network profile.
 * `name` - (Required) The name of the network profile.
 * `mtu` - (Required) The MTU of the network profile.
 * `gateway` - (Optional) The gateway for the network profile.

--- a/hcx/constants/constants.go
+++ b/hcx/constants/constants.go
@@ -1,0 +1,26 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package constants
+
+const (
+	// HCX Cloud URLs
+	HcxBaseURL          = "https://connect.hcx.vmware.com"
+	HcxCloudURL         = HcxBaseURL
+	HcxCloudAuthURL     = HcxBaseURL + "/provider/csp"
+	HcxCloudConsumerURL = HcxBaseURL + "/provider/csp/consumer"
+
+	// VMware Cloud URLs
+	VmcBaseURL = "https://console.cloud.vmware.com"
+	VmcAuthURL = VmcBaseURL + "/csp/gateway/am/api"
+
+	// Network Types
+	NetworkTypeDvpg       = "DistributedVirtualPortgroup"
+	NetworkTypeNsxSegment = "NsxtSegment"
+)
+
+var AllowedNetworkTypes = []string{
+	NetworkTypeDvpg,
+	NetworkTypeNsxSegment,
+}

--- a/hcx/data_source_network_backing.go
+++ b/hcx/data_source_network_backing.go
@@ -7,6 +7,9 @@ package hcx
 import (
 	"context"
 
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+	"github.com/vmware/terraform-provider-hcx/hcx/validators"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -33,10 +36,11 @@ func dataSourceNetworkBacking() *schema.Resource {
 				Computed:    true,
 			},
 			"network_type": {
-				Type:        schema.TypeString,
-				Description: "The type of the network backing. Allowed values are 'DistributedVirtualPortgroup' and 'NsxtSegment'.",
-				Optional:    true,
-				Default:     "DistributedVirtualPortgroup",
+				Type:         schema.TypeString,
+				Description:  fmt.Sprintf("The network type for the network backing. Allowed values include: %v.", constants.AllowedNetworkTypes),
+				Optional:     true,
+				Default:      constants.NetworkTypeDvpg,
+				ValidateFunc: validators.ValidateNetworkType,
 			},
 		},
 	}

--- a/hcx/resource_activation.go
+++ b/hcx/resource_activation.go
@@ -7,6 +7,8 @@ package hcx
 import (
 	"context"
 
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -24,7 +26,7 @@ func resourceActivation() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The URL for activation.",
 				Optional:    true,
-				Default:     "https://connect.hcx.vmware.com",
+				Default:     constants.HcxCloudURL,
 			},
 			"activationkey": {
 				Type:        schema.TypeString,

--- a/hcx/resource_l2_extension.go
+++ b/hcx/resource_l2_extension.go
@@ -8,7 +8,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
+
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+	"github.com/vmware/terraform-provider-hcx/hcx/validators"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -25,12 +29,12 @@ func resourceL2Extension() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"site_pairing": {
 				Type:        schema.TypeMap,
-				Description: "The site pairing used by this service mesh.",
+				Description: "The site pairing used for the L2 extension.",
 				Required:    true,
 			},
 			"service_mesh_id": {
 				Type:        schema.TypeString,
-				Description: "The ID of the Service Mesh to be used for this L2 extension.",
+				Description: "The ID of the Service Mesh to be used for the L2 extension.",
 				Required:    true,
 			},
 			"source_network": {
@@ -39,10 +43,11 @@ func resourceL2Extension() *schema.Resource {
 				Required:    true,
 			},
 			"network_type": {
-				Type:        schema.TypeString,
-				Description: "The network backing type. Allowed values include: 'DistributedVirtualPortgroup' and 'NsxtSegment'.",
-				Optional:    true,
-				Default:     "DistributedVirtualPortgroup",
+				Type:         schema.TypeString,
+				Description:  fmt.Sprintf("The network type for the L2 extension. Allowed values include: %v.", constants.AllowedNetworkTypes),
+				Optional:     true,
+				Default:      constants.NetworkTypeDvpg,
+				ValidateFunc: validators.ValidateNetworkType,
 			},
 			"destination_t1": {
 				Type:        schema.TypeString,

--- a/hcx/resource_network_profile.go
+++ b/hcx/resource_network_profile.go
@@ -8,6 +8,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+	"github.com/vmware/terraform-provider-hcx/hcx/validators"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -44,7 +47,7 @@ func NetSchema() map[string]*schema.Schema {
 		},
 		"site_pairing": {
 			Type:        schema.TypeMap,
-			Description: "The site pairing map, to be retrieved with the 'hcx_site_pairing' resource.",
+			Description: "The site pairing map for the network profile, to be retrieved with the 'hcx_site_pairing' resource.",
 			Required:    true,
 		},
 		"primary_dns": {
@@ -67,14 +70,15 @@ func NetSchema() map[string]*schema.Schema {
 		},
 		"network_name": {
 			Type:        schema.TypeString,
-			Description: "The network name used for the network profile.",
+			Description: "The network name for the network profile.",
 			Optional:    true,
 		},
 		"network_type": {
-			Type:        schema.TypeString,
-			Description: "The network type for the network profile.",
-			Optional:    true,
-			Default:     "DistributedVirtualPortgroup",
+			Type:         schema.TypeString,
+			Description:  fmt.Sprintf("The network type for the network profile. Allowed values include: %v.", constants.AllowedNetworkTypes),
+			Optional:     true,
+			Default:      constants.NetworkTypeDvpg,
+			ValidateFunc: validators.ValidateNetworkType,
 		},
 		"ip_range": {
 			Type:     schema.TypeList,

--- a/hcx/validators/validators.go
+++ b/hcx/validators/validators.go
@@ -1,0 +1,29 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"fmt"
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+)
+
+// ValidateNetworkType validates that the provided value is a string and matches one of the allowed network types.
+// Returns warnings and errors based on value validation.
+func ValidateNetworkType(val interface{}, key string) (warns []string, errs []error) {
+	networkType, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be a string, got: %T", key, val))
+		return warns, errs
+	}
+
+	for _, allowedType := range constants.AllowedNetworkTypes {
+		if networkType == allowedType {
+			return warns, errs
+		}
+	}
+
+	errs = append(errs, fmt.Errorf("%q must be one of %v, got: %s", key, constants.AllowedNetworkTypes, networkType))
+	return warns, errs
+}

--- a/hcx/vmc.go
+++ b/hcx/vmc.go
@@ -12,6 +12,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
 )
 
 type SDDC struct {
@@ -56,7 +58,7 @@ func VmcAuthenticate(token string) (string, error) {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://console.cloud.vmware.com/csp/gateway/am/api",
+		HostURL:    constants.VmcAuthURL,
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/auth/api-tokens/authorize?refresh_token=%s", c.HostURL, token), nil)
@@ -91,7 +93,7 @@ func CloudAuthenticate(client *Client, token string) error {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://connect.hcx.vmware.com/provider/csp",
+		HostURL:    constants.HcxCloudAuthURL,
 	}
 
 	body := CloudAuthorizationBody{
@@ -136,7 +138,7 @@ func GetSddcByName(client *Client, sddcName string) (SDDC, error) {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://connect.hcx.vmware.com/provider/csp/consumer",
+		HostURL:    constants.HcxCloudConsumerURL,
 		HcxToken:   client.HcxToken,
 	}
 
@@ -173,7 +175,7 @@ func GetSddcByID(client *Client, sddcID string) (SDDC, error) {
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://connect.hcx.vmware.com/provider/csp/consumer",
+		HostURL:    constants.HcxCloudConsumerURL,
 		HcxToken:   client.HcxToken,
 	}
 
@@ -212,7 +214,7 @@ func ActivateHcxOnSDDC(client *Client, sddcID string) (ActivateHcxOnSDDCResults,
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://connect.hcx.vmware.com/provider/csp/consumer",
+		HostURL:    constants.HcxCloudConsumerURL,
 		HcxToken:   client.HcxToken,
 	}
 
@@ -244,7 +246,7 @@ func DeactivateHcxOnSDDC(client *Client, sddcID string) (DeactivateHcxOnSDDCResu
 
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 60 * time.Second},
-		HostURL:    "https://connect.hcx.vmware.com/provider/csp/consumer",
+		HostURL:    constants.HcxCloudConsumerURL,
 		HcxToken:   client.HcxToken,
 	}
 


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Introduces several changes to centralize constants and improve validation within the provider. The key changes involve moving hardcoded strings to constants, adding validation functions, and updating references across multiple files.

Centralization of Constants:

* [`hcx/constants/constants.go`](diffhunk://#diff-bcce02011d982855f6d08e8a8e4a3e7693a4accedd8bcbedfcdc6bf340016969R1-R26): Added a new file to define constants for HCX and VMware Cloud URLs, network types, and allowed network types.

Validation Improvements:

* [`hcx/validators/validators.go`](diffhunk://#diff-fad1cf46b49f26a7b3ecc44084db0a0ca09f0f93524699982bee453ca7daea9bR1-R29): Introduced a new file to add a validation function `ValidateNetworkType` for ensuring network types are valid.

Code Refactoring:

* [`hcx/data_source_network_backing.go`](diffhunk://#diff-f84a146825f2b645da8e9a0cb16658188201f8ff203f3757318e92edffd2afd0R9-R10): Updated the default network type and added validation using the new constants and validators. [[1]](diffhunk://#diff-f84a146825f2b645da8e9a0cb16658188201f8ff203f3757318e92edffd2afd0R9-R10) [[2]](diffhunk://#diff-f84a146825f2b645da8e9a0cb16658188201f8ff203f3757318e92edffd2afd0L39-R42)
* [`hcx/resource_activation.go`](diffhunk://#diff-bf2cd3914aa059e3522367635aacd16538c17a53b3ea510210eb92f3130454d5R10-R11): Replaced hardcoded URL with the new constant for the HCX Cloud URL. [[1]](diffhunk://#diff-bf2cd3914aa059e3522367635aacd16538c17a53b3ea510210eb92f3130454d5R10-R11) [[2]](diffhunk://#diff-bf2cd3914aa059e3522367635aacd16538c17a53b3ea510210eb92f3130454d5L27-R29)
* [`hcx/resource_l2_extension.go`](diffhunk://#diff-b33f379614f9e117d32eb49dd07e26d64c320fe112fb993743d7165d068a1b52R11-R16): Updated the network type description and default value to use constants, and added validation. [[1]](diffhunk://#diff-b33f379614f9e117d32eb49dd07e26d64c320fe112fb993743d7165d068a1b52R11-R16) [[2]](diffhunk://#diff-b33f379614f9e117d32eb49dd07e26d64c320fe112fb993743d7165d068a1b52L43-R50)
* [`hcx/vmc.go`](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccR15-R16): Replaced hardcoded URLs with the new constants for VMware Cloud and HCX Cloud URLs in multiple functions. [[1]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccR15-R16) [[2]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL59-R61) [[3]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL94-R96) [[4]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL139-R141) [[5]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL176-R178) [[6]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL215-R217) [[7]](diffhunk://#diff-c1f7301507632ebe6e5cfe71630ef5f71bbbb3ce8efab959d8c0fefb66934bccL247-R249)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [x] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
