### PR TITLE
refactor: use constants

### DIFF
--- a/hcx/constants/constants.go
+++ b/hcx/constants/constants.go
@@ -4,6 +4,8 @@
 
 package constants
 
+import "time"
+
 const (
 	// HCX Cloud URLs
 	HcxBaseURL          = "https://connect.hcx.vmware.com"
@@ -18,6 +20,38 @@ const (
 	// Network Types
 	NetworkTypeDvpg       = "DistributedVirtualPortgroup"
 	NetworkTypeNsxSegment = "NsxtSegment"
+
+	// VMC
+	VmcMaxRetries                 = 12
+	VmcRetryInterval              = 10 * time.Second
+	VmcActivationActiveStatus     = "ACTIVE"
+	VmcActivationFailedStatus     = "ACTIVATION_FAILED"
+	VmcDeactivationInactiveStatus = "DE-ACTIVATED"
+	VmcDeactivationFailedStatus   = "DEACTIVATION_FAILED"
+
+	// Status
+	StoppedStatus  = "STOPPED"
+	RunningStatus  = "RUNNING"
+	FailedStatus   = "FAILED"
+	SuccessStatus  = "SUCCESS"
+	RealizedStatus = "REALIZED"
+
+	// Network Profile
+	DefaultNetworkProfileOrg = "DEFAULT"
+
+	// Location
+	DefaultLatitude  = 0
+	DefaultLongitude = 0
+
+	// Compute Profile
+	DefaultComputeType = "VC"
+
+	// Single Sign-On
+	DefaultSsoProviderType = "PSC"
+
+	// Role Mappings
+	RoleSystemAdmin     = "System Administrator"
+	RoleEnterpriseAdmin = "Enterprise Administrator"
 )
 
 var AllowedNetworkTypes = []string{

--- a/hcx/resource_compute_profile.go
+++ b/hcx/resource_compute_profile.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -185,7 +187,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		ID:   managementNetworkID,
 		Tags: []string{"management"},
 		Status: Status{
-			State: "REALIZED",
+			State: constants.RealizedStatus,
 		},
 	}
 	networksList = append(networksList, netTmp)
@@ -207,7 +209,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			ID:   replicationNetworkID,
 			Tags: []string{"replication"},
 			Status: Status{
-				State: "REALIZED",
+				State: constants.RealizedStatus,
 			},
 		}
 		networksList = append(networksList, netTmp)
@@ -230,7 +232,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			ID:   uplinkNetworkID,
 			Tags: []string{"uplink"},
 			Status: Status{
-				State: "REALIZED",
+				State: constants.RealizedStatus,
 			},
 		}
 		networksList = append(networksList, netTmp)
@@ -253,7 +255,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			ID:   vmotionNetworkID,
 			Tags: []string{"vmotion"},
 			Status: Status{
-				State: "REALIZED",
+				State: constants.RealizedStatus,
 			},
 		}
 		networksList = append(networksList, netTmp)
@@ -264,7 +266,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		Services: servicesFromSchema,
 		Computes: []Compute{{
 			ComputeID:   res.EntityID,
-			ComputeType: "VC",
+			ComputeType: constants.DefaultComputeType,
 			ComputeName: res.Name,
 			ID:          res.Children[0].EntityID,
 			Name:        res.Children[0].Name,
@@ -273,7 +275,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		DeploymentContainers: DeploymentContainer{
 			Computes: []Compute{{
 				ComputeID:   res.EntityID,
-				ComputeType: "VC",
+				ComputeType: constants.DefaultComputeType,
 				ComputeName: res.Name,
 				ID:          clusterID,
 				Name:        clusterName,
@@ -282,7 +284,7 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			},
 			Storage: []Storage{{
 				ComputeID:   res.EntityID,
-				ComputeType: "VC",
+				ComputeType: constants.DefaultComputeType,
 				ComputeName: res.Name,
 				ID:          datastoreFromAPI.ID,
 				Name:        datastoreFromAPI.Name,
@@ -316,11 +318,11 @@ func resourceComputeProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 
-		if jr.Status == "SUCCESS" {
+		if jr.Status == constants.SuccessStatus {
 			break
 		}
 
-		if jr.Status == "FAILED" {
+		if jr.Status == constants.FailedStatus {
 			return diag.FromErr(errors.New("task failed"))
 		}
 
@@ -365,11 +367,11 @@ func resourceComputeProfileDelete(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 
-		if jr.Status == "SUCCESS" {
+		if jr.Status == constants.SuccessStatus {
 			break
 		}
 
-		if jr.Status == "FAILED" {
+		if jr.Status == constants.FailedStatus {
 			return diag.FromErr(errors.New("task failed"))
 		}
 

--- a/hcx/resource_location.go
+++ b/hcx/resource_location.go
@@ -6,6 +6,7 @@ package hcx
 
 import (
 	"context"
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -127,8 +128,8 @@ func resourceLocationDelete(ctx context.Context, d *schema.ResourceData, m inter
 		City:      "",
 		Country:   "",
 		CityASCII: "",
-		Latitude:  0,
-		Longitude: 0,
+		Latitude:  constants.DefaultLatitude,
+		Longitude: constants.DefaultLongitude,
 		Province:  "",
 	}
 

--- a/hcx/resource_network_profile.go
+++ b/hcx/resource_network_profile.go
@@ -166,7 +166,7 @@ func resourceNetworkProfileCreate(ctx context.Context, d *schema.ResourceData, m
 
 	body := NetworkProfileBody{
 		Name:         name,
-		Organization: "DEFAULT",
+		Organization: constants.DefaultNetworkProfileOrg,
 		MTU:          mtu,
 		Backings: []Backing{{
 			BackingID:           networkiD.EntityID,

--- a/hcx/resource_rolemapping.go
+++ b/hcx/resource_rolemapping.go
@@ -6,6 +6,7 @@ package hcx
 
 import (
 	"context"
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -94,11 +95,11 @@ func resourceRoleMappingUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	body := []RoleMapping{
 		{
-			Role:       "System Administrator",
+			Role:       constants.RoleSystemAdmin,
 			UserGroups: adminGroups,
 		},
 		{
-			Role:       "Enterprise Administrator",
+			Role:       constants.RoleEnterpriseAdmin,
 			UserGroups: enterpriseGroups,
 		},
 	}
@@ -124,11 +125,11 @@ func resourceRoleMappingDelete(ctx context.Context, d *schema.ResourceData, m in
 	client := m.(*Client)
 	body := []RoleMapping{
 		{
-			Role:       "System Administrator",
+			Role:       constants.RoleSystemAdmin,
 			UserGroups: []string{},
 		},
 		{
-			Role:       "Enterprise Administrator",
+			Role:       constants.RoleEnterpriseAdmin,
 			UserGroups: []string{},
 		},
 	}

--- a/hcx/resource_service_mesh.go
+++ b/hcx/resource_service_mesh.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -202,11 +203,11 @@ func resourceServiceMeshCreate(ctx context.Context, d *schema.ResourceData, m in
 			return diag.FromErr(err)
 		}
 
-		if jr.Status == "SUCCESS" {
+		if jr.Status == constants.SuccessStatus {
 			break
 		}
 
-		if jr.Status == "FAILED" {
+		if jr.Status == constants.FailedStatus {
 			return diag.FromErr(errors.New("task failed"))
 		}
 
@@ -266,11 +267,11 @@ func resourceServiceMeshDelete(ctx context.Context, d *schema.ResourceData, m in
 			return diag.FromErr(err)
 		}
 
-		if jr.Status == "SUCCESS" {
+		if jr.Status == constants.SuccessStatus {
 			break
 		}
 
-		if jr.Status == "FAILED" {
+		if jr.Status == constants.FailedStatus {
 			return diag.FromErr(errors.New("task failed"))
 		}
 

--- a/hcx/resource_site_pairing.go
+++ b/hcx/resource_site_pairing.go
@@ -153,7 +153,7 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 		}
 
 		if jr.DidFail {
-			return diag.Errorf("Site pairing Job did failed")
+			return diag.Errorf("site pairing job failed")
 		}
 		time.Sleep(10 * time.Second)
 		count = count + 1
@@ -181,7 +181,7 @@ func resourceSitePairingCreate(ctx context.Context, d *schema.ResourceData, m in
 			}
 
 			if jr.DidFail {
-				return diag.Errorf("Site pairing Job did failed")
+				return diag.Errorf("site pairing job failed")
 			}
 			time.Sleep(10 * time.Second)
 			count = count + 1

--- a/hcx/resource_sso.go
+++ b/hcx/resource_sso.go
@@ -6,6 +6,7 @@ package hcx
 
 import (
 	"context"
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,7 +48,7 @@ func resourceSSOCreate(ctx context.Context, d *schema.ResourceData, m interface{
 				{
 					Config: InsertSSODataItemConfig{
 						LookupServiceURL: url,
-						ProviderType:     "PSC",
+						ProviderType:     constants.DefaultSsoProviderType,
 					},
 				},
 			},
@@ -61,7 +62,7 @@ func resourceSSOCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	if len(res.InsertSSOData.Items) == 0 {
-		// No SSO config found
+		// No SSO configuration found.
 		res, err := InsertSSO(client, body)
 
 		if err != nil {
@@ -72,7 +73,7 @@ func resourceSSOCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		return resourceSSORead(ctx, d, m)
 	}
 
-	// Update existing SSO
+	// Update existing SSO configuration.
 	d.SetId(res.InsertSSOData.Items[0].Config.UUID)
 	return resourceSSOUpdate(ctx, d, m)
 
@@ -99,7 +100,7 @@ func resourceSSOUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 					Config: InsertSSODataItemConfig{
 						LookupServiceURL: url,
 						UUID:             d.Id(),
-						ProviderType:     "PSC",
+						ProviderType:     constants.DefaultSsoProviderType,
 					},
 				},
 			},

--- a/hcx/resource_vcenter.go
+++ b/hcx/resource_vcenter.go
@@ -10,6 +10,8 @@ import (
 
 	b64 "encoding/base64"
 
+	"github.com/vmware/terraform-provider-hcx/hcx/constants"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -86,7 +88,7 @@ func resourcevCenterCreate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 
-		if jr.Result == "STOPPED" {
+		if jr.Result == constants.StoppedStatus {
 			break
 		}
 		time.Sleep(5 * time.Second)
@@ -104,7 +106,7 @@ func resourcevCenterCreate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 
-		if jr.Result == "RUNNING" {
+		if jr.Result == constants.RunningStatus {
 			break
 		}
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This pull request focuses on centralizing constant values by moving them to the `constants` package and updating the codebase to use these constants. The main changes include importing the `constants` package where needed, replacing hard-coded values with constants, and adding new constants for various statuses and configurations.

Centralizing Constants

* [`hcx/constants/constants.go`](diffhunk://#diff-bcce02011d982855f6d08e8a8e4a3e7693a4accedd8bcbedfcdc6bf340016969R23-R54): Added new constants for VMC statuses, general statuses, network profiles, locations, compute profiles, SSO provider types, and role mappings.

Updating Imports

* [`hcx/resource_compute_profile.go`](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5R12): Imported the `constants` package.
* [`hcx/resource_location.go`](diffhunk://#diff-c42dea953a474ba5e575cc52d0216fa4430cac9ace10b29331d98d9bef9e4bc4R9): Imported the `constants` package.
* [`hcx/resource_rolemapping.go`](diffhunk://#diff-7b6764649b384da9f4c1976dc8519021b94d22542f8bacd7e94ce4273425a5cdR9): Imported the `constants` package.
* [`hcx/resource_service_mesh.go`](diffhunk://#diff-21a7deca1a3f0f3294eccb6c805fee80354ec748c15446e256024bdc4e088fb3R12): Imported the `constants` package.
* [`hcx/resource_sso.go`](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aR9): Imported the `constants` package.
* [`hcx/resource_vcenter.go`](diffhunk://#diff-fd3cad94c65c01ddd5ab51876b2905aea46de78e95d7c165b06d60dfea0ea55aR9): Imported the `constants` package.
* [`hcx/resource_vmc.go`](diffhunk://#diff-ca07762e91585d0b5979a19099ab541a4376d03c3a42b938ae6f70ae35eb3566R9): Imported the `constants` package.

Replacing Hard-Coded Values

* [`hcx/resource_compute_profile.go`](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L188-R189): Replaced hard-coded status and compute type values with constants. [[1]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L188-R189) [[2]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L210-R211) [[3]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L233-R234) [[4]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L256-R257) [[5]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L267-R268) [[6]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L276-R277) [[7]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L285-R286) [[8]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L319-R324) [[9]](diffhunk://#diff-6bc32f4fb3e1ed21eca22acb3d62f01ca8e75eddb347a777989e758d9f8c97e5L368-R373)
* [`hcx/resource_location.go`](diffhunk://#diff-c42dea953a474ba5e575cc52d0216fa4430cac9ace10b29331d98d9bef9e4bc4L130-R132): Replaced hard-coded latitude and longitude values with constants.
* [`hcx/resource_network_profile.go`](diffhunk://#diff-e346a5059cf027c64026cc32b3810b49ce24184e8bae7b57fb8618213dce3220L169-R169): Replaced hard-coded organization value with a constant.
* [`hcx/resource_rolemapping.go`](diffhunk://#diff-7b6764649b384da9f4c1976dc8519021b94d22542f8bacd7e94ce4273425a5cdL97-R102): Replaced hard-coded role values with constants. [[1]](diffhunk://#diff-7b6764649b384da9f4c1976dc8519021b94d22542f8bacd7e94ce4273425a5cdL97-R102) [[2]](diffhunk://#diff-7b6764649b384da9f4c1976dc8519021b94d22542f8bacd7e94ce4273425a5cdL127-R132)
* [`hcx/resource_service_mesh.go`](diffhunk://#diff-21a7deca1a3f0f3294eccb6c805fee80354ec748c15446e256024bdc4e088fb3L205-R210): Replaced hard-coded status values with constants. [[1]](diffhunk://#diff-21a7deca1a3f0f3294eccb6c805fee80354ec748c15446e256024bdc4e088fb3L205-R210) [[2]](diffhunk://#diff-21a7deca1a3f0f3294eccb6c805fee80354ec748c15446e256024bdc4e088fb3L269-R274)
* [`hcx/resource_sso.go`](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL50-R51): Replaced hard-coded SSO provider type value with a constant. [[1]](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL50-R51) [[2]](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL102-R103)
* [`hcx/resource_vcenter.go`](diffhunk://#diff-fd3cad94c65c01ddd5ab51876b2905aea46de78e95d7c165b06d60dfea0ea55aL89-R90): Replaced hard-coded status values with constants. [[1]](diffhunk://#diff-fd3cad94c65c01ddd5ab51876b2905aea46de78e95d7c165b06d60dfea0ea55aL89-R90) [[2]](diffhunk://#diff-fd3cad94c65c01ddd5ab51876b2905aea46de78e95d7c165b06d60dfea0ea55aL107-R108)
* [`hcx/resource_vmc.go`](diffhunk://#diff-ca07762e91585d0b5979a19099ab541a4376d03c3a42b938ae6f70ae35eb3566L118-R127): Replaced hard-coded VMC status values and retry intervals with constants. [[1]](diffhunk://#diff-ca07762e91585d0b5979a19099ab541a4376d03c3a42b938ae6f70ae35eb3566L118-R127) [[2]](diffhunk://#diff-ca07762e91585d0b5979a19099ab541a4376d03c3a42b938ae6f70ae35eb3566L241-R255)

Minor Improvements

* [`hcx/resource_site_pairing.go`](diffhunk://#diff-e7ec2e2971ae22f6db3cccfde538c41fc0ac91f9019ca995b9b54b96d3a2f9b9L156-R156): Improved error messages for consistency. [[1]](diffhunk://#diff-e7ec2e2971ae22f6db3cccfde538c41fc0ac91f9019ca995b9b54b96d3a2f9b9L156-R156) [[2]](diffhunk://#diff-e7ec2e2971ae22f6db3cccfde538c41fc0ac91f9019ca995b9b54b96d3a2f9b9L184-R184)
* [`hcx/resource_sso.go`](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL64-R65): Improved comments for clarity. [[1]](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL64-R65) [[2]](diffhunk://#diff-4c8a4091349ad447410ba3d9244e4ca50203557e7c8111b1e6e7fcc974af059aL75-R76)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
