### PR TITLE
refactor: update errors

### DIFF
--- a/hcx/activation.go
+++ b/hcx/activation.go
@@ -36,34 +36,27 @@ type ActivateDataItemConfig struct {
 // PostActivate sends a request to activate a configuration using the provided body and returns the resulting
 // ActivateBody object. Returns an error if the request fails or the response cannot be parsed.
 func PostActivate(c *Client, body ActivateBody) (ActivateBody, error) {
-
 	resp := ActivateBody{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send admin POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal POST response: %w", err)
 	}
 
 	return resp, nil
@@ -72,64 +65,50 @@ func PostActivate(c *Client, body ActivateBody) (ActivateBody, error) {
 // GetActivate sends a request to retrieve the current activation configuration and returns the resulting ActivateBody
 // object. Returns an error if the request fails or the response cannot be parsed.
 func GetActivate(c *Client) (ActivateBody, error) {
-
 	resp := ActivateBody{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send admin GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal GET response: %w", err)
 	}
 
 	return resp, nil
 }
 
-// DeleteActivate sends a  request to remove the activation configuration using the provided body and returns the
+// DeleteActivate sends a request to remove the activation configuration using the provided body and returns the
 // resulting ActivateBody object. Returns an error if the request fails or the response cannot be parsed.
-
 func DeleteActivate(c *Client, body ActivateBody) (ActivateBody, error) {
-
 	resp := ActivateBody{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/hcx", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send admin DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal DELETE response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/certificate.go
+++ b/hcx/certificate.go
@@ -31,28 +31,22 @@ func InsertCertificate(c *Client, body InsertCertificateBody) (InsertCertificate
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/admin/certificates", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal POST response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/compute_profile.go
+++ b/hcx/compute_profile.go
@@ -7,7 +7,6 @@ package hcx
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -117,28 +116,22 @@ func InsertComputeProfile(c *Client, body InsertComputeProfileBody) (InsertCompu
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal POST response: %w", err)
 	}
 
 	return resp, nil
@@ -153,22 +146,17 @@ func DeleteComputeProfile(c *Client, computeProfileID string) (InsertComputeProf
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles/%s", c.HostURL, computeProfileID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to unmarshal DELETE response: %w", err)
 	}
 
 	return resp, nil
@@ -183,22 +171,17 @@ func GetComputeProfile(c *Client, endpointID string, computeProfileName string) 
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/computeProfiles?endpointId=%s", c.HostURL, endpointID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return GetComputeProfileResultItem{}, err
+		return GetComputeProfileResultItem{}, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetComputeProfileResultItem{}, err
+		return GetComputeProfileResultItem{}, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetComputeProfileResultItem{}, err
+		return GetComputeProfileResultItem{}, fmt.Errorf("failed to unmarshal GET response: %w", err)
 	}
 
 	for _, j := range resp.Items {
@@ -207,5 +190,5 @@ func GetComputeProfile(c *Client, endpointID string, computeProfileName string) 
 		}
 	}
 
-	return GetComputeProfileResultItem{}, errors.New("cant find compute profile")
+	return GetComputeProfileResultItem{}, fmt.Errorf("cannot find compute profile: %s", computeProfileName)
 }

--- a/hcx/jobs.go
+++ b/hcx/jobs.go
@@ -23,22 +23,17 @@ func AppEngineStart(c *Client) (AppEngineStartStopResult, error) {
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/components/appengine?action=start", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -52,22 +47,17 @@ func AppEngineStop(c *Client) (AppEngineStartStopResult, error) {
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/components/appengine?action=stop", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -81,22 +71,17 @@ func GetAppEngineStatus(c *Client) (AppEngineStartStopResult, error) {
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s:9443/components/appengine/status", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/l2_extension.go
+++ b/hcx/l2_extension.go
@@ -7,7 +7,6 @@ package hcx
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -96,28 +95,22 @@ func InsertL2Extension(c *Client, body InsertL2ExtensionBody) (InsertL2Extension
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/l2Extensions", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -132,22 +125,17 @@ func GetL2Extensions(c *Client, networkName string) (GetL2ExtensionsResultItem, 
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/l2Extensions", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return GetL2ExtensionsResultItem{}, err
+		return GetL2ExtensionsResultItem{}, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetL2ExtensionsResultItem{}, err
+		return GetL2ExtensionsResultItem{}, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetL2ExtensionsResultItem{}, err
+		return GetL2ExtensionsResultItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp.Items {
@@ -156,7 +144,7 @@ func GetL2Extensions(c *Client, networkName string) (GetL2ExtensionsResultItem, 
 		}
 	}
 
-	return GetL2ExtensionsResultItem{}, errors.New("cant find compute L2 extension")
+	return GetL2ExtensionsResultItem{}, fmt.Errorf("cannot find L2 extension for network name: %s", networkName)
 }
 
 // DeleteL2Extension sends a DELETE request to remove an L2 extension with the provided stretchID and returns the
@@ -167,22 +155,17 @@ func DeleteL2Extension(c *Client, stretchID string) (DeleteL2ExtensionResult, er
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/l2Extensions/%s", c.HostURL, stretchID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/location.go
+++ b/hcx/location.go
@@ -32,26 +32,24 @@ type GetLocationResult struct {
 }
 
 // SetLocation sends request to update the location configuration using the provided body. Returns an error if the
+// SetLocation sends request to update the location configuration using the provided body. Returns an error if the
 // request fails or cannot be sent.
 func SetLocation(c *Client, body SetLocationBody) error {
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/location", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return err
+		return fmt.Errorf("failed to create PUT request: %w", err)
 	}
 
-	// Send the request.
 	_, _, err = c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return err
+		return fmt.Errorf("failed to send PUT request: %w", err)
 	}
 
 	return nil
@@ -65,22 +63,17 @@ func GetLocation(c *Client) (GetLocationResult, error) {
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s:9443/api/admin/global/config/location", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/network_profile.go
+++ b/hcx/network_profile.go
@@ -7,7 +7,6 @@ package hcx
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -79,34 +78,27 @@ type NetworkProfileData struct {
 // InsertNetworkProfile sends a request to create a new network profile using the provided body and returns the
 // resulting NetworkProfileResult object. Returns an error if the request fails or the response cannot be parsed.
 func InsertNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileResult, error) {
-
 	resp := NetworkProfileResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/admin/hybridity/api/networks", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -116,7 +108,6 @@ func InsertNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileRes
 // matching the specified name. Returns an error if the request fails, the response cannot be parsed, or no profile is
 // found with the given name.
 func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
-
 	resp := []NetworkProfileBody{}
 	body := NetworkFilter{
 		Filter: Filter{
@@ -128,28 +119,22 @@ func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp {
@@ -158,14 +143,13 @@ func GetNetworkProfile(c *Client, name string) (NetworkProfileBody, error) {
 		}
 	}
 
-	return NetworkProfileBody{}, errors.New("cannot find network profile")
+	return NetworkProfileBody{}, fmt.Errorf("network profile with name '%s' not found", name)
 }
 
 // GetNetworkProfileByID sends a request to query the list of network profiles and returns the NetworkProfileBody object
 // matching the specified ID. Returns an error if the request fails, the response cannot be parsed, or no profile is
 // found with the given ID.
 func GetNetworkProfileByID(c *Client, id string) (NetworkProfileBody, error) {
-
 	resp := []NetworkProfileBody{}
 	body := NetworkFilter{
 		Filter: Filter{
@@ -177,28 +161,22 @@ func GetNetworkProfileByID(c *Client, id string) (NetworkProfileBody, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/networks?action=queryIpUsage", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return NetworkProfileBody{}, err
+		return NetworkProfileBody{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp {
@@ -207,34 +185,28 @@ func GetNetworkProfileByID(c *Client, id string) (NetworkProfileBody, error) {
 		}
 	}
 
-	return NetworkProfileBody{}, errors.New("cannot find network profile")
+	return NetworkProfileBody{}, fmt.Errorf("network profile with ID '%s' not found", id)
 }
 
 // DeleteNetworkProfile sends a DELETE request to remove a network profile identified by the provided networkID and
 // returns the resulting NetworkProfileResult object. Returns an error if the request fails or the response cannot be
 // parsed.
 func DeleteNetworkProfile(c *Client, networkID string) (NetworkProfileResult, error) {
-
 	resp := NetworkProfileResult{}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, networkID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -243,34 +215,27 @@ func DeleteNetworkProfile(c *Client, networkID string) (NetworkProfileResult, er
 // UpdateNetworkProfile sends a request to update a network profile using the provided body and returns the resulting
 // NetworkProfileResult object. Returns an error if the request fails or the response cannot be parsed.
 func UpdateNetworkProfile(c *Client, body NetworkProfileBody) (NetworkProfileResult, error) {
-
 	resp := NetworkProfileResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/hybridity/api/networks/%s", c.HostURL, body.ObjectID), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create PUT request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send PUT request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/role_mapping.go
+++ b/hcx/role_mapping.go
@@ -33,28 +33,22 @@ func PutRoleMapping(c *Client, body []RoleMapping) (RoleMappingResult, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s:9443/api/admin/global/config/roleMappings", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create PUT request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send PUT request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/service_mesh.go
+++ b/hcx/service_mesh.go
@@ -78,28 +78,22 @@ func InsertServiceMesh(c *Client, body InsertServiceMeshBody) (InsertServiceMesh
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/serviceMesh", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -114,22 +108,17 @@ func DeleteServiceMesh(c *Client, serviceMeshID string, force bool) (DeleteServi
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/interconnect/serviceMesh/%s?force=%v", c.HostURL, serviceMeshID, force), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/site_pairing.go
+++ b/hcx/site_pairing.go
@@ -74,34 +74,27 @@ type DeleteRemoteCloudConfigResult struct {
 // InsertSitePairing sends a request to create a new site pairing using the provided body and returns the resulting
 // PostRemoteCloudConfigResult object. Returns an error if the request fails or the response cannot be parsed.
 func InsertSitePairing(c *Client, body RemoteCloudConfigBody) (PostRemoteCloudConfigResult, error) {
-
 	resp := PostRemoteCloudConfigResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/cloudConfigs", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -110,27 +103,21 @@ func InsertSitePairing(c *Client, body RemoteCloudConfigBody) (PostRemoteCloudCo
 // GetSitePairings sends a GET request to retrieve all existing site pairings and returns the resulting
 // GetRemoteCloudConfigResult object. Returns an error if the request fails or the response cannot be parsed.
 func GetSitePairings(c *Client) (GetRemoteCloudConfigResult, error) {
-
 	resp := GetRemoteCloudConfigResult{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/cloudConfigs", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -140,27 +127,21 @@ func GetSitePairings(c *Client) (GetRemoteCloudConfigResult, error) {
 // the resulting DeleteRemoteCloudConfigResult object. Returns an error if the request fails or the response cannot be
 // parsed.
 func DeleteSitePairings(c *Client, endpointID string) (DeleteRemoteCloudConfigResult, error) {
-
 	resp := DeleteRemoteCloudConfigResult{}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/hybridity/api/endpointPairing/%s", c.HostURL, endpointID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/sso.go
+++ b/hcx/sso.go
@@ -53,27 +53,21 @@ type GetSSOResult struct {
 // GetSSO sends a GET request to retrieve the current SSO configuration and returns the resulting GetSSOResult object.
 // Returns an error if the request fails or the response cannot be parsed.
 func GetSSO(c *Client) (GetSSOResult, error) {
-
 	resp := GetSSOResult{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice", c.HostURL), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -82,34 +76,27 @@ func GetSSO(c *Client) (GetSSOResult, error) {
 // InsertSSO sends a POST request to create a new SSO configuration using the provided body and returns the resulting
 // InsertSSOResult object. Returns an error if the request fails or the response cannot be parsed.
 func InsertSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
-
 	resp := InsertSSOResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -118,34 +105,27 @@ func InsertSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 // UpdateSSO sends a POST request to update the existing SSO configuration using the provided body. It returns the
 // resulting InsertSSOResult object or an error if the request fails or the response cannot be parsed.
 func UpdateSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
-
 	resp := InsertSSOResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice/%s", c.HostURL, body.Data.Items[0].Config.UUID), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -154,27 +134,21 @@ func UpdateSSO(c *Client, body InsertSSOBody) (InsertSSOResult, error) {
 // DeleteSSO sends a DELETE request to remove the SSO configuration identified by the provided SSOUUID and returns the
 // resulting DeleteSSOResult object. Returns an error if the request fails or the response cannot be parsed.
 func DeleteSSO(c *Client, SSOUUID string) (DeleteSSOResult, error) {
-
 	resp := DeleteSSOResult{}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/lookupservice/%s", c.HostURL, SSOUUID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil

--- a/hcx/utils.go
+++ b/hcx/utils.go
@@ -7,9 +7,7 @@ package hcx
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -271,66 +269,52 @@ type GetApplianceResultItem struct {
 	NetworkExtensionCount int    `json:"networkExtensionCount"`
 }
 
-// GetJobResult sends a request to retrieve the result of a job identified by the provided jobID, returning a JobResult
-// object. Returns an error if the request fails or the response cannot be parsed.
+// GetJobResult sends a request to retrieve the result of a job identified by the provided jobID, returning a JobResult object.
 func GetJobResult(c *Client, jobID string) (JobResult, error) {
-
 	resp := JobResult{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/jobs/%s", c.HostURL, jobID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse job result response: %w", err)
 	}
 
 	return resp, nil
 }
 
-// GetTaskResult sends a request to retrieve the result of a task identified by the provided taskID, returning a
-// TaskResult object. Returns an error if the request fails or the response cannot be parsed.
+// GetTaskResult sends a request to retrieve the result of a task identified by the provided taskID.
 func GetTaskResult(c *Client, taskID string) (TaskResult, error) {
-
 	resp := TaskResult{}
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/hybridity/api/interconnect/tasks/%s", c.HostURL, taskID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create GET request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send GET request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse task result response: %w", err)
 	}
 
 	return resp, nil
 }
 
 // GetLocalContainer sends a request to retrieve the local resource container list and returns the first item as a
-// PostResourceContainerListResultDataItem. Returns an error if the request fails or the response cannot be parsed.
+// PostResourceContainerListResultDataItem.
 func GetLocalContainer(c *Client) (PostResourceContainerListResultDataItem, error) {
 
 	body := PostResourceContainerListBody{
@@ -345,37 +329,31 @@ func GetLocalContainer(c *Client) (PostResourceContainerListResultDataItem, erro
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := PostResourceContainerListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to send HTTP request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp.Data.Items[0], nil
 }
 
 // GetRemoteContainer sends a request to retrieve the remote resource container list and returns the first item as a
-// PostResourceContainerListResultDataItem. Returns an error if the request fails or the response cannot be parsed.
+// PostResourceContainerListResultDataItem.
 func GetRemoteContainer(c *Client) (PostResourceContainerListResultDataItem, error) {
 
 	body := PostResourceContainerListBody{
@@ -390,38 +368,31 @@ func GetRemoteContainer(c *Client) (PostResourceContainerListResultDataItem, err
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := PostResourceContainerListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/resourcecontainer/list", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to send HTTP request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return PostResourceContainerListResultDataItem{}, err
+		return PostResourceContainerListResultDataItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp.Data.Items[0], nil
 }
 
-// GetNetworkBacking sends a request to retrieve a network's backing information by matching the given endpointID,
-// network, and networkType. Returns a Dvpg object or an error if it cannot find the network info.
-func GetNetworkBacking(c *Client, endpointID string, network string, networkType string) (Dvpg, error) {
+// GetNetworkBacking sends a request to retrieve a network's backing information.
+func GetNetworkBacking(c *Client, endpointID, network, networkType string) (Dvpg, error) {
 
 	body := PostNetworkBackingBody{
 		Filter: PostNetworkBackingBodyFilter{
@@ -434,35 +405,25 @@ func GetNetworkBacking(c *Client, endpointID string, network string, networkType
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return Dvpg{}, err
+		return Dvpg{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := PostNetworkBackingResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/networks", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return Dvpg{}, err
+		return Dvpg{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return Dvpg{}, err
+		return Dvpg{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return Dvpg{}, err
+		return Dvpg{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
-
-	log.Printf("*************************************")
-	log.Printf("networks list: %+v", resp)
-	log.Printf("*************************************")
 
 	for _, j := range resp.Data.Items {
 		if j.Name == network && j.EntityType == networkType {
@@ -470,11 +431,10 @@ func GetNetworkBacking(c *Client, endpointID string, network string, networkType
 		}
 	}
 
-	return Dvpg{}, errors.New("cannot find network info")
+	return Dvpg{}, fmt.Errorf("failed to find matching network info in GetNetworkBacking")
 }
 
-// GetVcInventory sends a request to retrieve the inventory of vCenter resources and returns the first item as a
-// GetVcInventoryResultDataItem. Returns an error if the request fails or the response cannot be parsed.
+// GetVcInventory sends a request to retrieve the vCenter resource inventory.
 func GetVcInventory(c *Client) (GetVcInventoryResultDataItem, error) {
 
 	var jsonBody = []byte("{}")
@@ -484,30 +444,24 @@ func GetVcInventory(c *Client) (GetVcInventoryResultDataItem, error) {
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/list", c.HostURL), buf)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcInventoryResultDataItem{}, err
+		return GetVcInventoryResultDataItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcInventoryResultDataItem{}, err
+		return GetVcInventoryResultDataItem{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcInventoryResultDataItem{}, err
+		return GetVcInventoryResultDataItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp.Data.Items[0], nil
 }
 
-// GetVcDatastore sends a request to query the vCenter datastore, matching the given datastoreName, vcuuid, and cluster.
-// Returns the matching GetVcDatastoreResultDataItem or an error if the datastore cannot be found.
-func GetVcDatastore(c *Client, datastoreName string, vcuuid string, cluster string) (GetVcDatastoreResultDataItem, error) {
+// GetVcDatastore sends a request to query a vCenter datastore.
+func GetVcDatastore(c *Client, datastoreName, vcuuid, cluster string) (GetVcDatastoreResultDataItem, error) {
 
 	body := GetVcDatastoreBody{
 		Filter: GetVcDatastoreFilter{
@@ -520,30 +474,24 @@ func GetVcDatastore(c *Client, datastoreName string, vcuuid string, cluster stri
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDatastoreResultDataItem{}, err
+		return GetVcDatastoreResultDataItem{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := GetVcDatastoreResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/datastores/query", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDatastoreResultDataItem{}, err
+		return GetVcDatastoreResultDataItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDatastoreResultDataItem{}, err
+		return GetVcDatastoreResultDataItem{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDatastoreResultDataItem{}, err
+		return GetVcDatastoreResultDataItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp.Data.Items {
@@ -552,12 +500,11 @@ func GetVcDatastore(c *Client, datastoreName string, vcuuid string, cluster stri
 		}
 	}
 
-	return GetVcDatastoreResultDataItem{}, errors.New("cannot find datastore")
+	return GetVcDatastoreResultDataItem{}, fmt.Errorf("datastore not found in GetVcDatastore")
 }
 
-// GetVcDvs sends a request to query a distributed switch matching the given dvsName, vcuuid, and cluster. Returns the
-// matching GetVcDvsResultDataItem or an error if the DVS cannot be found.
-func GetVcDvs(c *Client, dvsName string, vcuuid string, cluster string) (GetVcDvsResultDataItem, error) {
+// GetVcDvs sends a request to query a distributed switch.
+func GetVcDvs(c *Client, dvsName, vcuuid, cluster string) (GetVcDvsResultDataItem, error) {
 
 	body := GetVcDvsBody{
 		Filter: GetVcDvsFilter{
@@ -570,30 +517,24 @@ func GetVcDvs(c *Client, dvsName string, vcuuid string, cluster string) (GetVcDv
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDvsResultDataItem{}, err
+		return GetVcDvsResultDataItem{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := GetVcDvsResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/vc/dvs/query", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDvsResultDataItem{}, err
+		return GetVcDvsResultDataItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDvsResultDataItem{}, err
+		return GetVcDvsResultDataItem{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetVcDvsResultDataItem{}, err
+		return GetVcDvsResultDataItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp.Data.Items {
@@ -602,11 +543,10 @@ func GetVcDvs(c *Client, dvsName string, vcuuid string, cluster string) (GetVcDv
 		}
 	}
 
-	return GetVcDvsResultDataItem{}, errors.New("cannot find datastore")
+	return GetVcDvsResultDataItem{}, fmt.Errorf("distributed switch not found in GetVcDvs")
 }
 
-// GetRemoteCloudList sends a request to retrieve a list of remote clouds and returns the resulting PostCloudListResult
-// object. Returns an error if the request fails or the response cannot be parsed.
+// GetRemoteCloudList sends a request to retrieve a list of remote clouds and returns the resulting PostCloudListResult.
 func GetRemoteCloudList(c *Client) (PostCloudListResult, error) {
 
 	body := PostCloudListBody{
@@ -618,37 +558,30 @@ func GetRemoteCloudList(c *Client) (PostCloudListResult, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := PostCloudListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
 }
 
-// GetLocalCloudList sends a request to retrieve a list of local clouds and returns the resulting PostCloudListResult
-// object. Returns an error if the request fails or the response cannot be parsed.
+// GetLocalCloudList sends a request to retrieve a list of local clouds and returns the resulting PostCloudListResult.
 func GetLocalCloudList(c *Client) (PostCloudListResult, error) {
 
 	body := PostCloudListBody{
@@ -660,38 +593,31 @@ func GetLocalCloudList(c *Client) (PostCloudListResult, error) {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := PostCloudListResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/service/inventory/cloud/list", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return PostCloudListResult{}, err
+		return PostCloudListResult{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
 }
 
-// GetAppliance sends a request to query appliances based on the given endpointID and serviceMeshID. It returns a
-// matching GetApplianceResultItem (with a network extension count less than 9) or the first item in the response.
-// Returns an error if the request fails or no matching item is found.
+// GetAppliance sends a request to query appliances based on the given endpointID and serviceMeshID.
+// It returns a matching GetApplianceResultItem (with a network extension count less than 9) or an error.
 func GetAppliance(c *Client, endpointID string, serviceMeshID string) (GetApplianceResultItem, error) {
 
 	body := GetApplianceBody{
@@ -704,30 +630,24 @@ func GetAppliance(c *Client, endpointID string, serviceMeshID string) (GetApplia
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return GetApplianceResultItem{}, err
+		return GetApplianceResultItem{}, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	resp := GetApplianceResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return GetApplianceResultItem{}, err
+		return GetApplianceResultItem{}, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return GetApplianceResultItem{}, err
+		return GetApplianceResultItem{}, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return GetApplianceResultItem{}, err
+		return GetApplianceResultItem{}, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	for _, j := range resp.Items {
@@ -739,8 +659,8 @@ func GetAppliance(c *Client, endpointID string, serviceMeshID string) (GetApplia
 	return resp.Items[0], nil
 }
 
-// GetAppliances sends a request to retrieve all appliances matching the given endpointID and serviceMeshID. Returns a
-// slice of GetApplianceResultItem objects or an error if the request fails or the response cannot be parsed.
+// GetAppliances sends a request to retrieve all appliances matching the given endpointID and serviceMeshID.
+// Returns a slice of GetApplianceResultItem objects or an error if the request fails.
 func GetAppliances(c *Client, endpointID string, serviceMeshID string) ([]GetApplianceResultItem, error) {
 
 	body := GetApplianceBody{
@@ -754,30 +674,24 @@ func GetAppliances(c *Client, endpointID string, serviceMeshID string) ([]GetApp
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return []GetApplianceResultItem{}, err
+		return []GetApplianceResultItem{}, fmt.Errorf("failed to encode request bodys: %w", err)
 	}
 
 	resp := GetApplianceResult{}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/hybridity/api/interconnect/appliances/query", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return []GetApplianceResultItem{}, err
+		return []GetApplianceResultItem{}, fmt.Errorf("failed to POST create requests: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return []GetApplianceResultItem{}, err
+		return []GetApplianceResultItem{}, fmt.Errorf("failed to send POST requests: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return []GetApplianceResultItem{}, err
+		return []GetApplianceResultItem{}, fmt.Errorf("failed to parse HTTP responses: %w", err)
 	}
 
 	return resp.Items, nil

--- a/hcx/vcenter.go
+++ b/hcx/vcenter.go
@@ -48,34 +48,27 @@ type DeletevCenterResult struct {
 // InsertvCenter sends a request to add a new vCenter instance configuration using the provided body and returns the
 // resulting InsertvCenterResult object. Returns an error if the request fails or the response cannot be parsed.
 func InsertvCenter(c *Client, body InsertvCenterBody) (InsertvCenterResult, error) {
-
 	resp := InsertvCenterResult{}
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(body)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to encode request body: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s:9443/api/admin/global/config/vcenter", c.HostURL), &buf)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create POST request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send POST request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil
@@ -85,27 +78,21 @@ func InsertvCenter(c *Client, body InsertvCenterBody) (InsertvCenterResult, erro
 // returns the resulting DeletevCenterResult object. Returns an error if the request fails or the response cannot be
 // parsed.
 func DeletevCenter(c *Client, vCenterUUID string) (DeletevCenterResult, error) {
-
 	resp := DeletevCenterResult{}
 
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s:9443/api/admin/global/config/vcenter/%s", c.HostURL, vCenterUUID), nil)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to create DELETE request: %w", err)
 	}
 
-	// Send the request.
 	_, r, err := c.doAdminRequest(req)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to send DELETE request: %w", err)
 	}
 
-	// Parse response body.
 	err = json.Unmarshal(r, &resp)
 	if err != nil {
-		fmt.Println(err)
-		return resp, err
+		return resp, fmt.Errorf("failed to parse HTTP response: %w", err)
 	}
 
 	return resp, nil


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This pull request focuses on improving error handling and logging across various functions in the `hcx` package. The changes replace simple error returns and print statements with more descriptive error messages using `fmt.Errorf`.

Improvements to error handling:

* [`hcx/activation.go`](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L39-R63): Enhanced error messages in `PostActivate`, `GetActivate`, and `DeleteActivate` functions to provide more context when encoding request bodies, creating HTTP requests, sending requests, and parsing responses. [[1]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L39-R63) [[2]](diffhunk://#diff-9bd646dda755b5f7e6a942134584026d2d19049688d6196b0620846f3da6df76L75-R121)
* [`hcx/certificate.go`](diffhunk://#diff-73333f714840ba3f587cab1dd634dca4e693d942368b6eb797c530b7d93b5546R31-R53): Improved error messages in `InsertCertificate` function to include specific failure points during request body encoding, HTTP request creation, request sending, and response parsing.
* [`hcx/client.go`](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L65-R71): Updated error handling in `HcxConnectorAuthenticate`, `doRequest`, `doAdminRequest`, and `doVmcRequest` functions to provide clearer error messages for various failure scenarios such as authentication, HTTP request execution, and response reading. [[1]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L65-R71) [[2]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L87-R106) [[3]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L125-L136) [[4]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L165-R159) [[5]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L183-R188) [[6]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L224-R227) [[7]](diffhunk://#diff-0ff810b53c6f8f56e0050f875e34d5943daa197be720ec0c39bd1a5573168e01L262-R261)
* [`hcx/compute_profile.go`](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL10): Enhanced error messages in `InsertComputeProfile`, `DeleteComputeProfile`, and `GetComputeProfile` functions to provide more detailed context for failures during request creation, request sending, and response parsing. [[1]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL10) [[2]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL120-R136) [[3]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL156-R163) [[4]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL186-R190) [[5]](diffhunk://#diff-6386c8a1cce0f3a4bb49caf9559ba8ee1bb2a03c0aa223b80ad190c23daa8dbaL210-R199)
* [`hcx/jobs.go`](diffhunk://#diff-af2b383ba2e92d5615a189bb530c387b044c521ca87d0c3f7d752e958e931811L26-R38): Improved error messages in `AppEngineStart`, `AppEngineStop`, and `GetAppEngineStatus` functions to include specific failure points during HTTP request creation, request sending, and response parsing. [[1]](diffhunk://#diff-af2b383ba2e92d5615a189bb530c387b044c521ca87d0c3f7d752e958e931811L26-R38) [[2]](diffhunk://#diff-af2b383ba2e92d5615a189bb530c387b044c521ca87d0c3f7d752e958e931811L55-R64) [[3]](diffhunk://#diff-af2b383ba2e92d5615a189bb530c387b044c521ca87d0c3f7d752e958e931811L84-R90)
* [`hcx/l2_extension.go`](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L10): Enhanced error messages in `InsertL2Extension` and `GetL2Extensions` functions to provide more detailed context for failures during request creation, request sending, and response parsing. [[1]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L10) [[2]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L99-R115) [[3]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L135-R142) [[4]](diffhunk://#diff-4425f99a5ba9793a31d154ad55c710354a0b79bd40a11a018c6115664480acd1L159-R151)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
