### PR TITLE
chore(gh): update to goreleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,21 +1,20 @@
+---
 version: 2
+
+project_name: terraform-provider-hcx
 
 before:
   hooks:
     - go mod tidy
+
 builds:
-  - env:
-      - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    flags:
-      - -trimpath
-    ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  - id: default
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
     goos:
-      - freebsd
-      - windows
       - linux
+      - windows
       - darwin
+      - freebsd
     goarch:
       - amd64
       - '386'
@@ -24,18 +23,29 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
 archives:
-  - format: zip
+  - id: default
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    formats: ['zip']
+
 checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
-  algorithm: sha256
+
 signs:
-  - artifacts: checksum
+  - id: default
+    artifacts: checksum
     args:
       - "--batch"
       - "--local-user"
@@ -44,9 +54,12 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+
 release:
+  disable: true
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+
 changelog:
   disable: true


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

- Updates the GoReleaser configuration to v2.
- Uses the recommended order.

Before:

```shell
terraform-provider-hcx …
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:

```shell
terraform-provider-hcx on  main via 🐹 v1.24.1 
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • pipe skipped or partially skipped                reason=release is disabled
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
