### PR TITLE
refactor: drop else and outdent

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,9 +43,6 @@ linters:
           - revive
         text: unused-parameter
       - linters:
-          - revive
-        text: indent-error-flow
-      - linters:
           - gosec
         text: G402
       - linters:

--- a/hcx/resource_network_profile.go
+++ b/hcx/resource_network_profile.go
@@ -356,12 +356,11 @@ func resourceNetworkProfileDelete(ctx context.Context, d *schema.ResourceData, m
 			}
 		*/
 		return diags
-	} else {
-		res, err = DeleteNetworkProfile(client, d.Id())
+	}
+	res, err = DeleteNetworkProfile(client, d.Id())
 
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// Wait for job completion


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

* Removed the `revive` linter configuration for `indent-error-flow` from the `.golangci.yml` file, simplifying the linter setup. (`[.golangci.ymlL45-L47](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L45-L47)`)

* Adjusted the `resourceNetworkProfileDelete` function to fix improper handling of the `else` block, ensuring correct execution flow when deleting a network profile. (`[hcx/resource_network_profile.goL359-L365](diffhunk://#diff-e346a5059cf027c64026cc32b3810b49ce24184e8bae7b57fb8618213dce3220L359-L365)`)

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
