### PR TITLE
fix: check error return values from d.Set in resource functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,9 +34,6 @@ linters:
     rules:
       # TODO: Setting temporary exclusions.
       - linters:
-          - errcheck
-        text: Error return value of `d.Set` is not checked
-      - linters:
           - revive
         text: unused-parameter
     paths:

--- a/hcx/resource_location.go
+++ b/hcx/resource_location.go
@@ -79,11 +79,21 @@ func resourceLocationRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	d.SetId(resp.City)
-	d.Set("cityascii", resp.City)
-	d.Set("country", resp.Country)
-	d.Set("province", resp.Province)
-	d.Set("latitude", resp.Latitude)
-	d.Set("longitude", resp.Longitude)
+	if err := d.Set("cityascii", resp.City); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("country", resp.Country); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("province", resp.Province); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("latitude", resp.Latitude); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("longitude", resp.Longitude); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/hcx/resource_service_mesh.go
+++ b/hcx/resource_service_mesh.go
@@ -228,7 +228,9 @@ func resourceServiceMeshCreate(ctx context.Context, d *schema.ResourceData, m in
 		a["id"] = j.ApplianceID
 		tmp = append(tmp, a)
 	}
-	d.Set("appliances_id", tmp)
+	if err := d.Set("appliances_id", tmp); err != nil {
+		return diag.FromErr(err)
+	}
 
 	d.SetId(res2.Data.ServiceMeshID)
 

--- a/hcx/resource_site_pairing.go
+++ b/hcx/resource_site_pairing.go
@@ -215,15 +215,23 @@ func resourceSitePairingRead(ctx context.Context, d *schema.ResourceData, m inte
 				return diag.FromErr(errors.New("cannot get local container info"))
 			}
 
-			d.Set("local_vc", lc.VcUUID)
+			if err := d.Set("local_vc", lc.VcUUID); err != nil {
+				return diag.FromErr(err)
+			}
 
 			rc, err := GetRemoteContainer(client)
 			if err != nil {
 				return diag.FromErr(errors.New("cannot get remote container info"))
 			}
-			d.Set("remote_resource_id", rc.ResourceID)
-			d.Set("remote_resource_type", rc.ResourceType)
-			d.Set("remote_resource_name", rc.ResourceName)
+			if err := d.Set("remote_resource_id", rc.ResourceID); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := d.Set("remote_resource_type", rc.ResourceType); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := d.Set("remote_resource_name", rc.ResourceName); err != nil {
+				return diag.FromErr(err)
+			}
 
 			// Update Remote Cloud Info
 			res2, err := GetRemoteCloudList(client)
@@ -232,8 +240,12 @@ func resourceSitePairingRead(ctx context.Context, d *schema.ResourceData, m inte
 			}
 			for _, j := range res2.Data.Items {
 				if j.URL == url {
-					d.Set("remote_name", j.Name)
-					d.Set("remote_endpoint_type", res2.Data.Items[0].EndpointType)
+					if err := d.Set("remote_name", j.Name); err != nil {
+						return diag.FromErr(err)
+					}
+					if err := d.Set("remote_endpoint_type", res2.Data.Items[0].EndpointType); err != nil {
+						return diag.FromErr(err)
+					}
 				}
 			}
 
@@ -242,8 +254,12 @@ func resourceSitePairingRead(ctx context.Context, d *schema.ResourceData, m inte
 			if err != nil {
 				return diag.FromErr(errors.New("cannot get remote cloud info"))
 			}
-			d.Set("local_endpoint_id", res3.Data.Items[0].EndpointID)
-			d.Set("local_name", res3.Data.Items[0].Name)
+			if err := d.Set("local_endpoint_id", res3.Data.Items[0].EndpointID); err != nil {
+				return diag.FromErr(err)
+			}
+			if err := d.Set("local_name", res3.Data.Items[0].Name); err != nil {
+				return diag.FromErr(err)
+			}
 
 			return diags
 		}

--- a/hcx/resource_vmc.go
+++ b/hcx/resource_vmc.go
@@ -175,9 +175,15 @@ func resourceVmcRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	}
 
 	d.SetId(sddc.ID)
-	d.Set("cloud_url", sddc.CloudURL)
-	d.Set("cloud_name", sddc.CloudName)
-	d.Set("cloud_type", sddc.CloudType)
+	if err := d.Set("cloud_url", sddc.CloudURL); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cloud_name", sddc.CloudName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cloud_type", sddc.CloudType); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/terraform-provider-hcx/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Check and handle error return values from all `d.Set` calls in resource read functions to comply with errcheck linter requirements. This improves error handling and prevents silent failures when setting resource data.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

For bug fixes or features:

- [x] Tests have been completed.
- [ ] Documentation has been added/updated.

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
